### PR TITLE
Validate ellipsoid semi-axes in calculate_phi_nodal

### DIFF
--- a/Source/DiffusedIB.cpp
+++ b/Source/DiffusedIB.cpp
@@ -138,6 +138,8 @@ void calculate_phi_nodal(MultiFab& phi_nodal, kernel& current_kernel)
             );
         } else if (geometry_type == 2) {
             // Ellipsoid geometry
+            AMREX_ALWAYS_ASSERT_WITH_MESSAGE(current_kernel.radius2 > 0.0 && current_kernel.radius3 > 0.0,
+                "geometry_type = 2 (ellipsoid) requires radius2 and radius3 to be set to positive values");
             Real b = current_kernel.radius2;  // semi-axis b
             Real c = current_kernel.radius3; // semi-axis c
             amrex::ParallelFor(bx, [=]

--- a/Source/DiffusedIB_Parallel.cpp
+++ b/Source/DiffusedIB_Parallel.cpp
@@ -152,6 +152,8 @@ void calculate_phi_nodal(MultiFab& phi_nodal, kernel& current_kernel)
             );
         } else if (geometry_type == 2) {
             // Ellipsoid geometry
+            AMREX_ALWAYS_ASSERT_WITH_MESSAGE(current_kernel.radius2 > 0.0 && current_kernel.radius3 > 0.0,
+                "geometry_type = 2 (ellipsoid) requires radius2 and radius3 to be set to positive values");
             Real b = current_kernel.radius2;  // semi-axis b
             Real c = current_kernel.radius3; // semi-axis c
             ParallelFor(bx, [=]


### PR DESCRIPTION
geometry_type = 2 (ellipsoid) reads the second and third semi-axes directly off the kernel. radius2/radius3 default to 0.0, so an ellipsoid input missing either extra radius made b2/c2 zero and the level set kernel divide by zero, filling phi_nodal with inf/NaN that propagated into the volume fraction and the flow solution.

cal_momentum in the same files already guards these values by falling back to the sphere radius, so the moment of inertia and the level set disagreed for the same missing input. Fail loudly instead of falling back silently: a missing semi-axis is an input error, not a shorthand.

Add an AMREX_ALWAYS_ASSERT_WITH_MESSAGE in the ellipsoid branch of calculate_phi_nodal, outside the ParallelFor (it must not run on the device), in both the serial and PARTICLE_PARALLEL variants. cal_momentum is unchanged.