### PR TITLE
Bound the ellipsoid level set denominator so the centre survives FP32

### DIFF
--- a/Source/DiffusedIB.cpp
+++ b/Source/DiffusedIB.cpp
@@ -140,6 +140,9 @@ void calculate_phi_nodal(MultiFab& phi_nodal, kernel& current_kernel)
             // Ellipsoid geometry
             Real b = current_kernel.radius2;  // semi-axis b
             Real c = current_kernel.radius3; // semi-axis c
+            // Floor the denominator relative to the smallest semi-axis so that the
+            // centre of the particle stays representable, including in FP32 builds.
+            const Real denom_floor = Real(1.e-6) * amrex::min(a, amrex::min(b, c));
             amrex::ParallelFor(bx, [=]
                 AMREX_GPU_DEVICE(int i, int j, int k) noexcept
                 {
@@ -175,7 +178,7 @@ void calculate_phi_nodal(MultiFab& phi_nodal, kernel& current_kernel)
                     Real denominator = 2.0 * std::sqrt(xp4 / a4 + yp4 / b4 + zp4 / c4);
 
                     // Do not normalize here!
-                    pnfab(i,j,k) = numerator / (denominator + 1.e-12);
+                    pnfab(i,j,k) = numerator / amrex::max(denominator, denom_floor);
 
                 }
             );

--- a/Source/DiffusedIB_Parallel.cpp
+++ b/Source/DiffusedIB_Parallel.cpp
@@ -154,6 +154,9 @@ void calculate_phi_nodal(MultiFab& phi_nodal, kernel& current_kernel)
             // Ellipsoid geometry
             Real b = current_kernel.radius2;  // semi-axis b
             Real c = current_kernel.radius3; // semi-axis c
+            // Floor the denominator relative to the smallest semi-axis so that the
+            // centre of the particle stays representable, including in FP32 builds.
+            const Real denom_floor = Real(1.e-6) * amrex::min(a, amrex::min(b, c));
             ParallelFor(bx, [=]
                 AMREX_GPU_DEVICE(int i, int j, int k) noexcept
                 {
@@ -189,7 +192,7 @@ void calculate_phi_nodal(MultiFab& phi_nodal, kernel& current_kernel)
                     Real denominator = 2.0 * std::sqrt(xp4 / a4 + yp4 / b4 + zp4 / c4);
 
                     // Do not normalize here!
-                    pnfab(i,j,k) = numerator / (denominator + 1.e-12);
+                    pnfab(i,j,k) = numerator / amrex::max(denominator, denom_floor);
 
                 }
             );


### PR DESCRIPTION
The ellipsoid level set divides by (denominator + 1.e-12). At the exact centre of the particle the denominator is zero, so the fixed guard manufactures a value of -1.0e12 -- twelve orders of magnitude larger than every neighbouring node. nodal_phi_to_pvf then averages the eight nodes of each cell; in a PRECISION=FLOAT build, adding the other seven nodes to 1.0e12 changes nothing, so every cell touching the centre node gets a volume fraction computed from one node instead of eight and the result saturates at 1.0.

Scale the floor to the geometry instead: clamp the denominator to 1.e-6 times the smallest semi-axis, so the centre stays representable in both double and single precision. The Real(...) cast keeps the 1.e-6 literal from forcing double arithmetic into the kernel. Applied to both the serial and PARTICLE_PARALLEL variants. The level set formula itself and the deo + 1.e-12 guard in nodal_phi_to_pvf are unchanged.