### PR TITLE
Update contact email in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,4 +142,4 @@ We are grateful to Ann Almgren, Andy Nonaka, Andrew Myers, Axel Huebl, Marc Day,
 
 ## Contact
 
-If you have any questions or would like to contribute to the code, please don't hesitate to contact us via the [GitHub Issues](https://github.com/ruohai0925/IAMReX/issues) or zdsjtu@gmail.com.
+If you have any questions or would like to contribute to the code, please don't hesitate to contact us via the [GitHub Issues](https://github.com/ruohai0925/IAMReX/issues) or ruohai372@gmail.com.


### PR DESCRIPTION
The Contact section pointed readers to zdsjtu@gmail.com. Replace it with the current contact address ruohai372@gmail.com. The GitHub Issues link and the rest of the sentence are unchanged. This touches exactly one line; the zdsjtu@gmail.com strings in SPDX-FileCopyrightText headers and REUSE.toml are copyright attribution and deliberately out of scope.