### PR TITLE
Reject unsupported geometry_type instead of silently ignoring it

### DIFF
--- a/Source/DiffusedIB.H
+++ b/Source/DiffusedIB.H
@@ -66,7 +66,7 @@ struct kernel{
     Real radius{0.0};
     Real radius2{0.0};
     Real radius3{0.0};
-    int geometry_type{1};  // 1 = sphere, 2 = ellipsoid, 3 = cylinder
+    int geometry_type{1};  // 1 = sphere, 2 = ellipsoid; any other value aborts
     Real rho{0.0};
     int ml{0};
     Real dv{0.0};

--- a/Source/DiffusedIB.cpp
+++ b/Source/DiffusedIB.cpp
@@ -179,7 +179,7 @@ void calculate_phi_nodal(MultiFab& phi_nodal, kernel& current_kernel)
 
                 }
             );
-        } else if (geometry_type > 2) {
+        } else {
             amrex::Print() << "Particle (" << current_kernel.id << ") has unsupported geometry_type: " << geometry_type << "\n";
             amrex::Abort("Unsupported geometry type. Only geometry_type = 1 (sphere) and 2 (ellipsoid) are supported.");
         }

--- a/Source/DiffusedIB_Parallel.H
+++ b/Source/DiffusedIB_Parallel.H
@@ -102,7 +102,7 @@ struct kernel{
     Real radius{0.0};
     Real radius2{0.0};
     Real radius3{0.0};
-    int geometry_type{1};  // 1 = sphere, 2 = ellipsoid, 3 = cylinder
+    int geometry_type{1};  // 1 = sphere, 2 = ellipsoid; any other value aborts
     Real rho{0.0};
     int ml{0};
     int start_id{0};

--- a/Source/DiffusedIB_Parallel.cpp
+++ b/Source/DiffusedIB_Parallel.cpp
@@ -193,7 +193,7 @@ void calculate_phi_nodal(MultiFab& phi_nodal, kernel& current_kernel)
 
                 }
             );
-        } else if (geometry_type > 2) {
+        } else {
             Print() << "Particle (" << current_kernel.id << ") has unsupported geometry_type: " << geometry_type << "\n";
             Abort("Unsupported geometry type. Only geometry_type = 1 (sphere) and 2 (ellipsoid) are supported.");
         }


### PR DESCRIPTION
calculate_phi_nodal dispatches on kernel::geometry_type with branches for 1 (sphere) and 2 (ellipsoid) and a final `else if (geometry_type > 2)` that prints and aborts. A geometry_type of 0 or negative matched no branch at all: nothing warned, phi_nodal stayed identically zero, and nodal_phi_to_pvf computed a volume fraction from an all-zero level set while the run continued producing physically meaningless results.

geometry_type is read from the inputs file, so a typo or an off-by-one in a particle list reaches this code directly. Turn the final branch into a plain else so that every value other than 1 and 2 is rejected with the existing message. Also correct the kernel struct comments in both headers, which listed "3 = cylinder" -- a geometry type that is not implemented and now aborts.

Applied to the serial and PARTICLE_PARALLEL variants, which are near-duplicates of the same immersed boundary code.