### PR TITLE
Fix delta-function support test in level-set mass_fix; correct two doc comments

### DIFF
--- a/Docs/IAMReX_documentation/source/LevelSet.rst
+++ b/Docs/IAMReX_documentation/source/LevelSet.rst
@@ -57,9 +57,9 @@ At the beginning of each time advancement of level :math:`l`, the velocity :math
       :label: eq:viscsolve
 
       \begin{aligned}
-      &\boldsymbol{u^{*,n+1}}-\frac{\Delta t}{2\rho(\phi^{n+1/2})Re}{\nabla} \cdot {\mu(\phi^{n+1})}{\nabla}\boldsymbol{u^{*,n+1}} =
+      &\boldsymbol{u^{*,n+1}}-\frac{\Delta t}{2\rho(\phi^{n+1/2})Re}{\nabla} \cdot {\mu(\phi^{n+1/2})}{\nabla}\boldsymbol{u^{*,n+1}} =
       \boldsymbol{u^n}-\Delta t \left[\nabla \cdot (\boldsymbol{uu})\right]^{n+1/2} + \\ &\frac{\Delta t}{\rho(\phi^{n+1/2})}\bigg[-\nabla p^{n-1/2}+
-      \frac{1}{2Re}{\nabla}\cdot{\mu(\phi^{n})}{\nabla}\boldsymbol{u^n} + \rho(\phi^{n+1/2}) \frac{z}{Fr^2} -  \frac{1}{We}\kappa(\phi^{n+1/2})\delta(x^{n+1/2})\boldsymbol{n}\bigg].
+      \frac{1}{2Re}{\nabla}\cdot{\mu(\phi^{n+1/2})}{\nabla}\boldsymbol{u^n} + \rho(\phi^{n+1/2}) \frac{z}{Fr^2} -  \frac{1}{We}\kappa(\phi^{n+1/2})\delta(x^{n+1/2})\boldsymbol{n}\bigg].
       \end{aligned}
 
    In equation :eq:`eq:viscsolve`, the detailed discretization of the advection term :math:`\nabla \cdot (\boldsymbol{uu})`, viscous term :math:`{\nabla}\cdot({\mu(\phi)}{\nabla}\boldsymbol{u})`, and surface tension term :math:`\kappa(\phi)\delta(x)\boldsymbol{n}/We` are implemented using standard finite difference schemes. The LS function at :math:`t^{n+1/2}` is calculated by
@@ -69,7 +69,7 @@ At the beginning of each time advancement of level :math:`l`, the velocity :math
 
       \phi^{n+1/2} = \frac{1}{2}(\phi^{n}+\phi^{n+1})
 
-   where :math:`\phi^{n+1}` is obtained from step 1 (equation :eq:`eq:s0phin1`). The :math:`\rho(\phi^{n+1/2})`, :math:`\mu(\phi^{n})`, and :math:`\mu(\phi^{n+1})` are then obtained from equations :eq:`eq:rho` and :eq:`eq:mu`.
+   where :math:`\phi^{n+1}` is obtained from step 1 (equation :eq:`eq:s0phin1`). Both :math:`\rho(\phi^{n+1/2})` and :math:`\mu(\phi^{n+1/2})` are then obtained from equations :eq:`eq:rho` and :eq:`eq:mu`; as in Sussman et al. (1999), the same mid-time viscosity multiplies both the explicit and the implicit halves of the Crank--Nicolson viscous term (this is what the code does: ``viscn_cc`` and ``viscnp1_cc`` are both filled from :math:`\phi^{n+1/2}`).
 
 3. **Apply the projection method** to obtain the pressure and a solenoidal velocity field. To conduct the level projection, a temporary variable :math:`\boldsymbol{V}` is defined as
 

--- a/Source/NavierStokesBase.cpp
+++ b/Source/NavierStokesBase.cpp
@@ -6103,9 +6103,10 @@ NavierStokesBase::mass_fix (MultiFab& phi_ctime,
         AMREX_GPU_DEVICE(int i, int j, int k) noexcept
         {
             ldfab(i,j,k) = (phifab(i,j,k) - phiorifab(i,j,k)) / tao;
-            if (phifab(i,j,k) > eps) {
-                deltafab(i,j,k) = 0.0;
-            } else if (phifab(i,j,k) > -eps) {
+            // H'_eps(d^0) (Sussman et al. 1999, eq. 68): the support test and the
+            // value must both use the original level set phi_original; testing on
+            // the current phi evaluated the cosine outside its support at band-edge cells.
+            if (std::abs(phiorifab(i,j,k)) <= eps) {
                 deltafab(i,j,k) = 0.5 * (1.0 + std::cos(phiorifab(i,j,k) * pi / eps)) / eps;
             } else {
                 deltafab(i,j,k) = 0.0;

--- a/Source/prob/prob_init.cpp
+++ b/Source/prob/prob_init.cpp
@@ -918,7 +918,8 @@ void NavierStokes::init_BreakingWave (Box const& vbx,
 // exact solution in 2D is
 //     u(x,y,t) =   Sin(2 Pi x) Cos(2 Pi y) Exp(-2 (2Pi)^2 Nu t)
 //     v(x,y,t) = - Cos(2 Pi x) Sin(2 Pi y) Exp(-2 (2Pi)^2 Nu t)
-//     p(x,y,t) = - {Cos(4 Pi x) + Cos(4 Pi y)} Exp(-4 (2Pi)^2 Nu t) / 4
+//     p(x,y,t) =   {Cos(4 Pi x) + Cos(4 Pi y)} Exp(-4 (2Pi)^2 Nu t) / 4
+//     (sign follows from -p_x = u u_x + v u_y = Pi Sin(4 Pi x) for this velocity field)
 // In Exec/benchmarks, there is a tool ViscBench2d.cpp that reads a
 // plot file and compares the solution against this exact solution.
 // This benchmark was originally derived by G.I. Taylor (Phil. Mag.,


### PR DESCRIPTION
## Summary

- `NavierStokesBase::mass_fix`: the smoothed delta function H'_eps(d0) of the Sussman–Fatemi volume constraint (Sussman et al. 1999, eq. 68) was branched on the *current* level set `phi` but evaluated with `phi_original`. Cells at the edge of the band therefore got either a cosine evaluated outside its support or zero. The support test now uses `phi_original` as well.
- `prob_init.cpp`: the comment giving the Taylor–Green pressure had the wrong sign for the velocity field used (`u = sin cos, v = -cos sin` gives `p = +1/4 (cos 4πx + cos 4πy) e^{-16π²νt}`, from `-p_x = u u_x + v u_y = π sin 4πx`). Code is unaffected.
- `LevelSet.rst`: the Crank–Nicolson viscous term uses `mu(phi^{n+1/2})` in both halves, which is what the code (`viscn_cc`, `viscnp1_cc`) and Sussman et al. (1999) do; the doc said `mu(phi^n)` / `mu(phi^{n+1})`.

## Test

`Tutorials/RSV` (2D, 64², T = 4, `ns.fixed_dt = 0.001953125`, no MPI) before and after: the phi > 0 area at t = 4 is identical to the printed digits (0.083203 → 0.083203), i.e. the fix only touches band-edge cells and has no visible effect at this resolution. Taylor–Green (`probtype = 11`, 64², ν = 0.01, t = 0.2) still gives L2(u) error 2.16e-4.

Found while writing an independent single-grid reimplementation of the LS algorithm and comparing it line by line with the paper; a follow-up will add an area diagnostic to the RSV tutorial (its current setup gains ~18 % area over one cycle, a known property of the eps-smoothed volume constraint on under-resolved filaments).