### PR TITLE
Add ns.epsilon_massfix and a phase-volume diagnostic for the level-set solver

### DIFF
--- a/Docs/IAMReX_documentation/source/LevelSet.rst
+++ b/Docs/IAMReX_documentation/source/LevelSet.rst
@@ -127,3 +127,12 @@ At last, we give a summary of the single-level advancement algorithm as follows 
 3. Apply the projection method to update the pressure and velocity field following equations :eq:`eq:ns_lp_ls1`--:eq:`eq:ns_lp_ls3`
 4. Re-initialize the LS function on the single level using equations :eq:`eq:ns_reinit1`--:eq:`eq:ns_reinit3`
 
+.. note::
+   The band half-width of :math:`H'_\varepsilon` used in the volume constraint of the
+   reinitialization step is controlled by ``ns.epsilon_massfix`` (in units of :math:`\Delta x`;
+   default: the same value as ``ns.epsilon``). The constraint conserves the
+   :math:`\varepsilon`-smoothed volume, which differs from the sharp volume where the interface is
+   thinner than :math:`2\varepsilon`; a narrower band (``ns.epsilon_massfix = 1``) keeps the sharp
+   phase volume much better in stretching flows (e.g. ``Tutorials/RSV``). When ``ns.do_phi = 1`` the
+   integrated-quantity output (``ns.sum_interval``, file ``mass.txt``) also reports the volume of the
+   :math:`\phi > 0` phase, smoothed and sharp.

--- a/Source/NavierStokes.cpp
+++ b/Source/NavierStokes.cpp
@@ -1022,6 +1022,44 @@ NavierStokes::sum_integrated_quantities ()
     Real energy = volumeWeightedSum(derived_mf_ptrs, 0,
                                     parent->Geom(), parent->refRatio());
 
+    //
+    // ls related: volume of the phi > 0 phase, smoothed (integral of H_eps(phi)) and sharp (cells with phi > 0)
+    //
+    Real vol_heavi = 0.0, vol_sharp = 0.0;
+    if (do_phi) {
+        Vector<std::unique_ptr<MultiFab>> heavi_mf(finest_level+1), sharp_mf(finest_level+1);
+        Vector<const MultiFab*> heavi_ptrs(finest_level+1), sharp_ptrs(finest_level+1);
+        for (int lev = 0; lev <= finest_level; lev++)
+        {
+            NavierStokes& ns_level = getLevel(lev);
+            MultiFab& S_new = ns_level.get_new_data(State_Type);
+            MultiFab phi_alias(S_new, amrex::make_alias, phicomp, 1);
+            // phi_to_heavi fills the grown box of phi, so the Heaviside field needs the same ghost cells
+            heavi_mf[lev] = std::make_unique<MultiFab>(S_new.boxArray(), S_new.DistributionMap(), 1, S_new.nGrow());
+            sharp_mf[lev] = std::make_unique<MultiFab>(S_new.boxArray(), S_new.DistributionMap(), 1, 0);
+            phi_to_heavi(ns_level.Geom(), epsilon, phi_alias, *heavi_mf[lev]);
+#ifdef AMREX_USE_OMP
+#pragma omp parallel if (Gpu::notInLaunchRegion())
+#endif
+            for (MFIter mfi(*sharp_mf[lev],TilingIfNotGPU()); mfi.isValid(); ++mfi)
+            {
+                const Box& bx = mfi.tilebox();
+                auto const& phifab   = phi_alias.const_array(mfi);
+                auto const& sharpfab = sharp_mf[lev]->array(mfi);
+                amrex::ParallelFor(bx, [phifab, sharpfab]
+                AMREX_GPU_DEVICE(int i, int j, int k) noexcept
+                {
+                    sharpfab(i,j,k) = (phifab(i,j,k) > 0.0) ? 1.0 : 0.0;
+                });
+            }
+            heavi_ptrs[lev] = heavi_mf[lev].get();
+            sharp_ptrs[lev] = sharp_mf[lev].get();
+        }
+        vol_heavi = volumeWeightedSum(heavi_ptrs, 0, parent->Geom(), parent->refRatio());
+        vol_sharp = volumeWeightedSum(sharp_ptrs, 0, parent->Geom(), parent->refRatio());
+        Print().SetPrecision(12) << "TIME= " << time << " PHASE VOLUME (phi>0, H_eps / sharp)= " << vol_heavi << " " << vol_sharp << '\n';
+    }
+
     Print() << '\n';
     Print().SetPrecision(12) << "TIME= " << time << " MASS= " << mass << '\n';
     Print().SetPrecision(12) << "TIME= " << time << " TRAC= " << trac << '\n';
@@ -1035,7 +1073,10 @@ NavierStokes::sum_integrated_quantities ()
         // std::ofstream ofs("mass.txt", std::ios::out); // override mode
         if (ofs.is_open())
         {
-            amrex::Print(ofs).SetPrecision(12) << time << " " << mass << " " << trac << " " << energy << '\n';
+            // columns: time  mass  tracer  kinetic_energy  [phase_volume_heaviside  phase_volume_sharp]
+            amrex::Print(ofs).SetPrecision(12) << time << " " << mass << " " << trac << " " << energy;
+            if (do_phi) amrex::Print(ofs).SetPrecision(12) << " " << vol_heavi << " " << vol_sharp;
+            amrex::Print(ofs) << '\n';
             ofs.close();
         }
         else

--- a/Source/NavierStokesBase.H
+++ b/Source/NavierStokesBase.H
@@ -1104,6 +1104,11 @@ public:
     amrex::MultiFab phi_original;
     amrex::MultiFab sgn0;
 
+    /** Band half-width (in units of dx) of the smoothed delta function used by the
+     *  Sussman-Fatemi volume constraint in mass_fix(). Defaults to ns.epsilon; a
+     *  narrower band (ns.epsilon_massfix = 1) conserves the sharp phase area much
+     *  better on under-resolved filaments (see Tutorials/RSV). */
+    static amrex::Real epsilon_massfix;
     static int  do_cons_phi;
     static int  prescribed_vel;
 

--- a/Source/NavierStokesBase.cpp
+++ b/Source/NavierStokesBase.cpp
@@ -224,6 +224,7 @@ int NavierStokesBase::lev0step_of_reinit = 1;
 int NavierStokesBase::number_of_reinit   = 4;
 int NavierStokesBase::reinit_levelset    = 1;
 
+Real NavierStokesBase::epsilon_massfix  = -1.0;   // <= 0: use epsilon
 int NavierStokesBase::do_cons_phi        = 0;
 int NavierStokesBase::prescribed_vel     = 0;
 
@@ -671,6 +672,7 @@ NavierStokesBase::Initialize ()
     pp.query("do_phi", do_phi);
     if (do_phi) {
         pp.query("epsilon", epsilon);
+        pp.query("epsilon_massfix", epsilon_massfix);
         pp.query("mu_a", mu_a);
         pp.query("mu_w", mu_w);
         pp.query("rho_a", rho_a);
@@ -6085,7 +6087,10 @@ NavierStokesBase::mass_fix (MultiFab& phi_ctime,
     if(verbose) amrex::Print() << "NavierStokesBase::mass_fix " << std::endl;
 
     const Real pi     = 3.141592653589793238462643383279502884197;
-    Real eps = calculate_eps(geom, epsilon);
+    // Band of H'_eps in the volume constraint (Sussman et al. 1999, eq. 68). It need not equal the
+    // Heaviside band used for rho/mu: the constraint conserves the eps-smoothed volume, and on
+    // filaments thinner than 2*eps a wide band pushes the zero contour outward (area gain).
+    Real eps = (epsilon_massfix > 0.0 ? epsilon_massfix : Real(epsilon)) * calculate_eps(geom, 1);
     Real tao = loop_iter * delta_t;
 
     // calculate ld and delta

--- a/Tutorials/RSV/inputs.2d.rsv
+++ b/Tutorials/RSV/inputs.2d.rsv
@@ -75,7 +75,7 @@ amr.check_int		= 500
 
 # Interval (in number of coarse timesteps) between plot files
 amr.plot_int		= 500
-ns.sum_interval     = 200
+ns.sum_interval     = 64
 
 #*******************************************************************************
 
@@ -152,4 +152,8 @@ ns.do_reinit          = 1
 ns.lev0step_of_reinit = 1
 ns.number_of_reinit   = 4
 ns.reinit_sussman     = 1
+# Band (in dx) of the delta function in the volume constraint of the redistancing step.
+# With the default (= ns.epsilon = 2) this case gains ~18% area over one T=4 cycle at 64^2;
+# with 1 the gain drops to ~4%. mass.txt (ns.sum_interval) records the phi>0 area.
+ns.epsilon_massfix    = 1
 ns.prescribed_vel     = 1


### PR DESCRIPTION
## Summary

The Sussman–Fatemi volume constraint in `NavierStokesBase::mass_fix` conserves the eps-smoothed volume ∫H_eps(phi). Where the interface is thinner than 2·eps (stretched filaments) that is not the sharp phase volume, and the constraint pushes the zero contour outward. The RSV tutorial (T = 4, 64², `ns.fixed_dt = 1/512`) gains **18 %** area over one cycle with the default band eps = 2 dx.

- New input **`ns.epsilon_massfix`** (units of dx; default = `ns.epsilon`, so nothing changes for existing inputs) sets the band of H'_eps used by the volume constraint only. `mass_fix` no longer ties it to the Heaviside band used for rho/mu.
- **`sum_integrated_quantities`** reports the volume of the phi > 0 phase (smoothed ∫H_eps and sharp cell count) when `do_phi = 1`, on screen and as two extra columns in `mass.txt`.
- `Tutorials/RSV/inputs.2d.rsv` enables `ns.epsilon_massfix = 1` and a finer `ns.sum_interval`, with the numbers below in a comment.
- `LevelSet.rst` documents both.

## Test (Tutorials/RSV, 2D, USE_MPI=FALSE)

| band of H'_eps | sharp phi>0 area, t=0 → t=4 | change |
|---|---|---|
| 2 dx (previous behaviour) | 0.07080 → 0.08374 | +18.3 % |
| 1 dx (new tutorial setting) | 0.07080 → 0.07397 | +4.5 % |

An independent single-grid re-implementation of the same algorithm predicts +17.1 % and +4.1 % for the two settings, and shows the trend continues (0.5 dx: −23 %), so 1 dx is the sweet spot for this case. For reference, Enright et al. (JCP 2002, Table 3) report the plain level-set method losing area on the stretching vortex; the gain here is specific to the smoothed-volume constraint.

Follow-up to #77.