### PR TITLE
Add prescribed traveling-wave fins in 2D and 3D

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,25 @@ xml
 .cache
 .idea
 build
+
+# Generated simulation data and build products (keep inputs and source files).
+plt[0-9]*/
+chk[0-9]*/
+fin_vtk/
+fin_[0-9]*.vtk
+IB_Fin_*.csv
+IB_Fiber_*.csv
+IB_Particle_*.csv
+Fiber_LagrangianPoints_*.csv
+fiber[0-9]*
+particle[0-9]*
+force-list/
+*.exe
+*.obj
+*.mod
+*.smod
+*.pdb
+*.ilk
+*.log
+__pycache__/
+*.pyc

--- a/Docs/Fin_Integration.md
+++ b/Docs/Fin_Integration.md
@@ -1,0 +1,51 @@
+# 二维、三维波动鳍代码整合
+
+## 来源和范围
+
+- 目标基线：`kkdxtd/IAMReX` 的 `main`，提交 `2cf74f43`。
+- 二维来源：`kkdxtd/IAMReX-2dIBMdev` 的 `main`，提交 `78e0184b`。
+- 三维来源：整合时本地 `IAMReX/Source` 及 `Tutorials/fin3d` 的工作文件。
+
+二维仓库与目标仓库没有共同 Git 祖先，因此采用代码移植，不合入旧仓库的
+删除记录、旧求解器版本或历史计算结果。目标基线的水平集质量修正、相体积
+诊断、椭球和 RKPM 代码予以保留。
+
+## 模块选择
+
+| 配置 | 实现 | 输入前缀 | 算例 |
+| --- | --- | --- | --- |
+| `DIM=2`, `USE_PARTICLES=TRUE` | `DiffusedFiber.H/.cpp` | `fiber.input` | `Tutorials/Fiber` |
+| `DIM=3`, `USE_PARTICLES=TRUE`, `PARTICLE_PARALLEL=FALSE` | `DiffusedIB.H/.cpp` | `particle.input`, `geometry_type=3` | `Tutorials/fin3d` |
+| `DIM=3`, `PARTICLE_PARALLEL=TRUE` | 原有 `DiffusedIB_Parallel.H/.cpp` | 原有粒子配置 | 原有 RKPM 算例 |
+
+`PARTICLE_PARALLEL` 是原有粒子/RKPM 实现的选择开关，不等于 `USE_MPI`。
+二维和三维鳍算例仍可使用 `USE_MPI=TRUE`。三维鳍需要使用普通 DIBM 路径；
+本次没有把 `geometry_type=3` 加入 RKPM 实现。二维、三维是分别编译的程序。
+
+## 整合适配
+
+- 将二维细丝代码提取为独立模块，按维度选择头文件和源码，隔离三维碰撞结构。
+- 保留二维绝对 x 坐标行波、原有点距/权重和惩罚力公式，以及三维转角行波、
+  边缘半权重、解析速度、力矩和 VTK 输出。
+- 将预定几何和目标速度对齐到新流场的 `time+dt`。二维初始化及重启根据
+  当前物理时间重建几何，力输出采用实际最细层步数，适配 AMR 子循环。
+- 三维普通 DIBM 的新接口与 RKPM 的旧接口分别调用，保留原有 RKPM 路径。
+- 初始化和输出挂钩仅在启用 DIBM 时访问鳍/粒子对象。
+- 保留本地 `velocity_magnitude` 派生变量，二维和三维均可用于流场输出。
+- 二维算例移除无效的第三维输入分量；三维保留本地有效参数，并修正文档与
+  注释：当前频率为 `1.0 Hz`，`amr.plot_int=-1` 关闭周期流场/鳍 VTK 输出。
+
+二维 CSV 保留旧代码的受力符号和密度约定，三维 CSV 为流体作用于鳍的
+有量纲力/力矩。详细公式见两个算例的 README，比较结果时需先统一约定。
+
+## 验证与文件范围
+
+本次仅进行文本差异、维度分支、接口对应、输入和提交清单检查。
+**未执行编译、求解器运行或数值测试；编译与数值验证由用户完成。**
+上传提交使用 `[skip ci]` 避免触发本次提交的 GitHub Actions 编译测试。
+后续自行提交时若不需要自动测试，也应注意仓库已有的 CI 触发规则。
+
+仅新增/修改源码、Make 配置、输入参数、说明文档和已有后处理脚本。
+不包含本地的 `IB_Fin_*.csv`、`IB_Fiber_*.csv`、`fin_vtk`、`force-list`、
+plotfile、checkpoint、日志或可执行文件。忽略规则不会删除本地结果；
+目标仓库基线中原有的参考数据也没有在本次改动中删除。

--- a/README.md
+++ b/README.md
@@ -56,6 +56,14 @@ IAMReX is a fork of the original [IAMR](https://github.com/AMReX-Fluids/IAMR) co
 
 - [Cluster of monodisperse particles](./Tutorials/Monodisperse/)
 
+- [Two-dimensional traveling-wave fin (fiber)](./Tutorials/Fiber/)
+
+- [Three-dimensional traveling-wave fin](./Tutorials/fin3d/)
+
+The prescribed-fin implementations share the DIBM solver and are selected by
+`DIM=2` or `DIM=3`. See the [integration notes](./Docs/Fin_Integration.md) for
+input conventions, source provenance, and validation status.
+
 For more details, please check the document: [sample-cases](https://ruohai0925.github.io/IAMReX/Introduction_Chapter.html#sample-cases)
 
 ## Installation

--- a/Source/DiffusedFiber.H
+++ b/Source/DiffusedFiber.H
@@ -1,0 +1,124 @@
+// SPDX-FileCopyrightText: 2023 - 2025 Yadong Zeng<zdsjtu@gmail.com> & ZhuXu Li<1246206018@qq.com>
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
+#ifndef DIFFUSEDFIBER_H
+#define DIFFUSEDFIBER_H
+
+#include <DiffusedIB.H>
+
+#if (AMREX_SPACEDIM == 2)
+struct fiber_kernel{
+    int id;                                    // 细丝编号
+    Real amplitude{0.0};                      // 振幅A
+    Real period{0.0};                         // 周期T
+    Real length{0.0};                         // 长度L
+    Real wave_number{0.0};                    // 波数n1
+    Real phase{0.0};                          // 初始相位phi1
+    int num_marker{0};                        // 拉格朗日点数
+
+    Real y0_base{0.0};                             // 基线
+
+    Vector<Real> x_marker;                    // 拉格朗日点x坐标数组
+    Vector<Real> y_marker;                    // 拉格朗日点y坐标数组
+    Vector<RealVect> velocity_marker;         // 拉格朗日点速度数组
+
+    amrex::Gpu::DeviceVector<Real> x_marker_d;
+    amrex::Gpu::DeviceVector<Real> y_marker_d;
+    amrex::Gpu::DeviceVector<RealVect> velocity_marker_d;
+
+    Real da{0.0};                          // 拉格朗日点面积
+    RealVect ib_force{0.0,0.0};          // 浸没边界法计算得到的力
+    int verbose{0};                           // 调试输出控制
+};
+
+class mFiberIter : public ParIter<0, 0, numAttri>{
+public:
+    using amrex::ParIter<0, 0, numAttri>::ParIter;
+    using RealVector = amrex::ParIter<0, 0, numAttri>::ContainerType::RealVector;
+
+    [[nodiscard]] const std::array<RealVector, numAttri>& GetAttribs () const {
+        return GetStructOfArrays().GetRealData();
+    }
+
+    [[nodiscard]] const RealVector& GetAttribs (int comp) const {
+        return GetStructOfArrays().GetRealData(comp);
+    }
+
+    std::array<RealVector, numAttri>& GetAttribs () {
+        return GetStructOfArrays().GetRealData();
+    }
+
+    RealVector& GetAttribs (int comp) {
+        return GetStructOfArrays().GetRealData(comp);
+    }
+};
+
+using mFiberContainer = ParticleContainer<0, 0, numAttri>;
+
+class mFiber
+{
+public:
+    explicit mFiber() = default;
+
+    void InitFibers(const Vector<Real>& x0,
+                     const Vector<Real>& y0,
+                     const Vector<Real>& amplitude,
+                     const Vector<Real>& period,
+                     const Vector<Real>& length,
+                     const Vector<Real>& wave_number,
+                     const Vector<Real>& phase,
+                     const Vector<int>& num_marker,
+                     Real h,
+                     int verbose = 0);
+
+    void InteractWithEuler(MultiFab &EulerVel, MultiFab &EulerForce,
+                           Real dt = 0.1, DELTA_FUNCTION_TYPE type = FOUR_POINT_IB,
+                           Real boundary_time = 0.0);
+
+    void WriteFiberFile(int index);
+
+    void InitialWithLargrangianPoints(const fiber_kernel& current_kernel);
+
+    void ResetLargrangianPoints();
+
+    void VelocityInterpolation(amrex::MultiFab &Euler, DELTA_FUNCTION_TYPE type);
+
+    void ComputeLagrangianForce(Real dt, const fiber_kernel& kernel);
+
+    void ForceSpreading(amrex::MultiFab &Euler, fiber_kernel& kernel, DELTA_FUNCTION_TYPE type);
+
+    void VelocityCorrection(amrex::MultiFab &Euler, amrex::MultiFab &EulerForce, Real dt) const;
+
+    void UpdateFibers(int iStep, Real time, Real dt);
+
+    // Reconstruct prescribed positions and velocities, including on restart.
+    void UpdateGeometry(Real time);
+
+    static void WriteIBForceAndMoment(int step, amrex::Real time, amrex::Real dt, fiber_kernel& current_kernel);
+
+    Vector<fiber_kernel> fiber_kernels;        // 所有细丝的fiber_kernel对象数组
+    mFiberContainer *mContainer{nullptr};       // AMReX的ParticleContainer，存储拉格朗日点
+    int max_largrangian_num = 0;               // 最大拉格朗日点数
+    int verbose = 0;                           // 调试输出控制
+    Real spend_time;
+};
+
+class Fibers{
+public:
+    static void create_fibers(const Geometry &gm,
+                               const DistributionMapping & dm,
+                               const BoxArray & ba);
+
+    static mFiber* get_fibers();
+    static void init_fiber(Real gravity, Real h);
+    static void Initialize();
+    static int FiberFinestLevel();
+
+    inline static bool isInitial{false};
+private:
+    inline static mFiber* fiber = nullptr;
+};
+
+#endif
+#endif

--- a/Source/DiffusedFiber.cpp
+++ b/Source/DiffusedFiber.cpp
@@ -1,0 +1,739 @@
+// SPDX-FileCopyrightText: 2023 - 2025 Yadong Zeng<zdsjtu@gmail.com> & ZhuXu Li<1246206018@qq.com>
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <DiffusedFiber.H>
+#include <AMReX_Math.H>
+#include <AMReX_ParmParse.H>
+#include <AMReX_Utility.H>
+#include <cmath>
+#include <filesystem>
+
+namespace fs = std::filesystem;
+using namespace amrex;
+
+#define LOCAL_LEVEL 0
+
+#if (AMREX_SPACEDIM == 2)
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void deltaFunction(Real xf, Real xp, Real h, Real& value, DELTA_FUNCTION_TYPE type)
+{
+    Real rr = amrex::Math::abs(( xf - xp ) / h);
+
+    switch (type) {
+    case DELTA_FUNCTION_TYPE::FOUR_POINT_IB:
+        if(rr >= 0 && rr < 1 ){
+            value = 1.0 / 8.0 * ( 3.0 - 2.0 * rr + std::sqrt( 1.0 + 4.0 * rr - 4 * Math::powi<2>(rr))) / h;
+        }else if (rr >= 1 && rr < 2) {
+            value = 1.0 / 8.0 * ( 5.0 - 2.0 * rr - std::sqrt( -7.0 + 12.0 * rr - 4 * Math::powi<2>(rr))) / h;
+        }else {
+            value = 0;
+        }
+        break;
+    case DELTA_FUNCTION_TYPE::THREE_POINT_IB:
+        if(rr >= 0.5 && rr < 1.5){
+            value = 1.0 / 6.0 * ( 5.0 - 3.0 * rr - std::sqrt( - 3.0 * Math::powi<2>( 1 - rr) + 1.0 )) / h;
+        }else if (rr >= 0 && rr < 0.5) {
+            value = 1.0 / 3.0 * ( 1.0 + std::sqrt( 1.0 - 3 * Math::powi<2>(rr))) / h;
+        }else {
+            value = 0;
+        }
+        break;
+    default:
+        break;
+    }
+}
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                    mParticle/mFiber member function                  */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+namespace FiberProperties{
+    Vector<Real> x0{}, y0{};                    // 细丝起点坐标
+    Vector<Real> amplitude{};                   // 振幅A
+    Vector<Real> period{};                      // 周期T
+    Vector<Real> length{};                      // 长度L
+    Vector<Real> wave_number{};                 // 波数n1
+    Vector<Real> phase{};                       // 初始相位phi1
+    Vector<int> num_marker{};                   // 拉格朗日点数
+    int euler_finest_level{0};                  // 最细网格等级
+    int euler_velocity_index{0};                // 欧拉速度场索引
+    int euler_force_index{0};                   // 欧拉力场索引
+    Real euler_fluid_rho{0.0};                  // 流体密度
+    int verbose{0};                             // 调试输出
+    int loop_ns{2};                             // 欧拉-拉格朗日交互迭代次数
+    int start_step{-1};                         // 开始步数
+    int write_freq{1};                          // 输出频率
+    Vector<Real> GLO, GHI;                      // 几何边界
+    GpuArray<Real, 2> plo{0.0,0.0}, phi{0.0,0.0}, dx{0.0, 0.0};
+}
+
+void mFiber::InteractWithEuler(MultiFab &EulerVel, MultiFab &EulerForce,
+                              Real dt, DELTA_FUNCTION_TYPE type, Real boundary_time)
+{
+    if (verbose) amrex::Print() << "[Fiber] mFiber::InteractWithEuler\n";
+    UpdateGeometry(boundary_time);
+
+    // 清零时间记录
+    spend_time = 0;
+    auto InteractWithEulerStart = ParallelDescriptor::second();
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(dt > 0.0, "fiber coupling requires dt > 0");
+
+    MultiFab EulerForceTmp(EulerForce.boxArray(), EulerForce.DistributionMap(), 2, EulerForce.nGrow());
+
+
+    // 清零所有细丝的IB力
+    for(auto& fiber_kernel : fiber_kernels) {
+        fiber_kernel.ib_force.scale(0.0);
+    }
+
+    // 欧拉-拉格朗日交互主循环
+    int loop = FiberProperties::loop_ns;
+    BL_ASSERT(loop > 0);
+    while(loop > 0){
+        if(verbose) amrex::Print() << "[Fiber] Ns loop index : " << loop << "\n";
+
+        EulerForce.setVal(0.0);
+
+        for(fiber_kernel& fiber_kernel : fiber_kernels){
+            // 初始化拉格朗日点位置
+            InitialWithLargrangianPoints(fiber_kernel);
+            ResetLargrangianPoints();
+            EulerForceTmp.setVal(0.0);
+
+            // 保存旧的IB力
+            auto ib_force = fiber_kernel.ib_force;
+            fiber_kernel.ib_force.scale(0.0);
+
+            // IBM核心步骤
+            VelocityInterpolation(EulerVel, type);
+            ComputeLagrangianForce(dt, fiber_kernel);
+            ForceSpreading(EulerForceTmp, fiber_kernel, type);
+
+            // 累加所有细丝的力到总欧拉力场
+            MultiFab::Add(EulerForce, EulerForceTmp, 0, 0, 2, EulerForce.nGrow());
+
+            // 恢复IB力
+            fiber_kernel.ib_force += ib_force;
+        }
+
+        // 速度修正
+        VelocityCorrection(EulerVel, EulerForce, dt);
+        loop--;
+    }
+
+    spend_time += ParallelDescriptor::second() - InteractWithEulerStart;
+}
+
+void mFiber::InitFibers(const Vector<Real>& x0,
+                         const Vector<Real>& y0,
+                         const Vector<Real>& amplitude,
+                         const Vector<Real>& period,
+                         const Vector<Real>& length,
+                         const Vector<Real>& wave_number,
+                         const Vector<Real>& phase,
+                         const Vector<int>& num_marker,
+                         Real h,
+                         int _verbose)
+{
+    verbose = _verbose;
+    if (verbose) amrex::Print() << "[Fiber] mFiber::InitFibers\n";
+
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(!x0.empty(), "at least one fiber is required");
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+        y0.size() == x0.size() && amplitude.size() == x0.size()
+        && period.size() == x0.size() && length.size() == x0.size()
+        && wave_number.size() == x0.size() && phase.size() == x0.size()
+        && num_marker.size() == x0.size(), "fiber parameter arrays must have matching sizes");
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(h > 0.0, "fiber grid spacing must be positive");
+
+    for(int index = 0; index < x0.size(); index++){
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(length[index] > 0.0 && period[index] > 0.0,
+            "fiber length and period must be positive");
+        fiber_kernel mKernel;
+        mKernel.id = index + 1;
+        mKernel.amplitude = amplitude[index];
+        mKernel.period = period[index];
+        mKernel.length = length[index];
+        mKernel.wave_number = wave_number[index];
+        mKernel.phase = phase[index];
+        mKernel.num_marker = num_marker[index];
+
+        mKernel.y0_base = y0[index];  //保存基线
+
+        //计算拉格朗日点数，确保两端端点都有点，间距为网格长度h
+        int num_points = static_cast<int>(std::ceil(length[index] / h)) + 1;
+        // The legacy implementation reuses the first fiber's marker container.
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(index == 0 || num_points == fiber_kernels[0].num_marker,
+            "fibers sharing the marker container must have the same marker count");
+        mKernel.num_marker = num_points;
+
+        // 初始化拉格朗日点位置（使用计算得到的 mKernel.num_marker 保持一致）
+        for (int i = 0; i < mKernel.num_marker; i++) {
+            Real x_pos = x0[index] + i * h;
+            Real y_pos = y0[index] + amplitude[index] *
+                         sin(2 * Math::pi<Real>() * (-wave_number[index] * x_pos / length[index]) + phase[index]);
+
+            mKernel.x_marker.push_back(x_pos);
+            mKernel.y_marker.push_back(y_pos);
+            mKernel.velocity_marker.push_back(RealVect(0.0, 0.0));
+        }
+
+        // 计算面积 da，仿照三维颗粒中 dv 的计算方式
+        Real da = h * h;// 每个拉格朗日点对应的面积，假设为 h^2
+        mKernel.da = da;
+
+        //mKernel.x_marker_d.assign(mKernel.x_marker.begin(), mKernel.x_marker.end());
+        //mKernel.y_marker_d.assign(mKernel.y_marker.begin(), mKernel.y_marker.end());
+        //mKernel.velocity_marker_d.assign(mKernel.velocity_marker.begin(), mKernel.velocity_marker.end());
+        // 同步到 device
+        mKernel.x_marker_d.resize(mKernel.x_marker.size());
+        amrex::Gpu::copyAsync(amrex::Gpu::hostToDevice,
+                              mKernel.x_marker.begin(), mKernel.x_marker.end(),
+                              mKernel.x_marker_d.begin());
+
+        mKernel.y_marker_d.resize(mKernel.y_marker.size());
+        amrex::Gpu::copyAsync(amrex::Gpu::hostToDevice,
+                              mKernel.y_marker.begin(), mKernel.y_marker.end(),
+                              mKernel.y_marker_d.begin());
+
+        mKernel.velocity_marker_d.resize(mKernel.velocity_marker.size());
+        amrex::Gpu::copyAsync(amrex::Gpu::hostToDevice,
+                              mKernel.velocity_marker.begin(), mKernel.velocity_marker.end(),
+                              mKernel.velocity_marker_d.begin());
+        amrex::Gpu::streamSynchronize();
+
+        fiber_kernels.emplace_back(mKernel);
+
+        if (verbose) amrex::Print() << "Fiber " << index << ": x0=" << x0[index]
+                                    << ", y0=" << y0[index] << ", amplitude=" << amplitude[index]
+                                    << ", period=" << period[index] << ", length=" << length[index]
+                                    << ", num_marker=" << num_marker[index] << "\n";
+    }
+}
+
+void mFiber::InitialWithLargrangianPoints(const fiber_kernel& kernel)
+{
+    if (verbose) amrex::Print() << "mFiber::InitialWithLargrangianPoints\n";
+
+    for(mFiberIter pti(*mContainer, LOCAL_LEVEL); pti.isValid(); ++pti){
+        const Long np = pti.numParticles();
+        if(np == 0) continue;
+        auto *particles = pti.GetArrayOfStructs().data();
+
+        // 获取细丝的拉格朗日点坐标
+        //const auto* x_marker = kernel.x_marker.data();
+        //const auto* y_marker = kernel.y_marker.data();
+        const auto* x_marker = kernel.x_marker_d.dataPtr();
+        const auto* y_marker = kernel.y_marker_d.dataPtr();
+
+        amrex::ParallelFor( np, [=]
+            AMREX_GPU_DEVICE (int i) noexcept {
+                auto id = particles[i].id();
+                // 设置拉格朗日点位置（沿细丝长度方向分布）
+                particles[i].pos(0) = x_marker[id - 1];
+                particles[i].pos(1) = y_marker[id - 1];
+            }
+        );
+    }
+
+    // 重新分布拉格朗日点
+    mContainer->Redistribute();
+
+    if (verbose) {
+        amrex::Print() << "[fiber] : fiber marker num :" << mContainer->TotalNumberOfParticles() << "\n";
+        mContainer->WriteAsciiFile(amrex::Concatenate("fiber", 1));
+    }
+
+    //if (verbose) {
+        // 统计全局总数，而非单个进程本地数
+    //    long local_cnt = static_cast<long>(mContainer->NumberOfParticles());
+    //    ParallelDescriptor::ReduceLongSum(local_cnt);
+    //    amrex::Print() << "[fiber] : fiber marker num (global) :" << local_cnt << "\n";
+    //    mContainer->WriteAsciiFile(amrex::Concatenate("fiber", 1));
+    //}
+}
+
+template <typename P = Particle<numAttri>>
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void VelocityInterpolation_cir(int p_iter, P const& p,
+                               Real& Up, Real& Vp,
+                               Array4<Real const> const& E, int EulerVIndex,
+                               const int *lo, const int *hi,
+                               GpuArray<Real, AMREX_SPACEDIM> const& plo,
+                               GpuArray<Real, AMREX_SPACEDIM> const& dx,
+                               DELTA_FUNCTION_TYPE type)
+{
+    // 体积计算
+    const Real d = dx[0] * dx[1];
+
+    // 坐标计算
+    const Real lx = (p.pos(0) - plo[0]) / dx[0];
+    const Real ly = (p.pos(1) - plo[1]) / dx[1];
+    int i = static_cast<int>(Math::floor(lx));
+    int j = static_cast<int>(Math::floor(ly));
+
+
+    // 初始化速度分量
+    Up = 0; Vp = 0;
+
+
+    // 循环
+    for(int ii = -2; ii < 3; ii++){
+        for(int jj = -2; jj < 3; jj++){
+            Real tU, tV;
+            const Real xi = plo[0] + (i + ii) * dx[0] + dx[0]/2;
+            const Real yj = plo[1] + (j + jj) * dx[1] + dx[1]/2;
+            deltaFunction(p.pos(0), xi, dx[0], tU, type);
+            deltaFunction(p.pos(1), yj, dx[1], tV, type);
+            const Real delta_value = tU * tV;
+            Up += delta_value * E(i + ii, j + jj, 0, EulerVIndex    ) * d;
+            Vp += delta_value * E(i + ii, j + jj, 0, EulerVIndex + 1) * d;
+        }
+    }
+}
+
+void mFiber::VelocityInterpolation(MultiFab &EulerVel, DELTA_FUNCTION_TYPE type)
+{
+    if (verbose) amrex::Print() << "\tmFiber::VelocityInterpolation\n";
+
+    const auto& gm = mContainer->GetParGDB()->Geom(LOCAL_LEVEL);
+    auto plo = gm.ProbLoArray();
+    auto dx = gm.CellSizeArray();
+
+    // 边界填充
+    EulerVel.FillBoundary(FiberProperties::euler_velocity_index, 2, gm.periodicity());
+
+
+    const int EulerVelocityIndex = FiberProperties::euler_velocity_index;
+
+    for (mFiberIter pti(*mContainer, LOCAL_LEVEL); pti.isValid(); ++pti) {
+        const Box& box = pti.validbox();
+        auto& particles = pti.GetArrayOfStructs();
+        auto *p_ptr = particles.data();
+        const Long np = pti.numParticles();
+
+        auto& attri = pti.GetAttribs();
+        auto* Up = attri[P_ATTR::U_Marker].data();
+        auto* Vp = attri[P_ATTR::V_Marker].data();
+        const auto& E = EulerVel.array(pti);
+
+        amrex::ParallelFor(np, [=]
+        AMREX_GPU_DEVICE (int i) noexcept {
+            VelocityInterpolation_cir(i, p_ptr[i], Up[i], Vp[i], E, EulerVelocityIndex, box.loVect(), box.hiVect(), plo, dx, type);
+        });
+    }
+
+    if (verbose) mContainer->WriteAsciiFile(amrex::Concatenate("fiber", 2));
+}
+
+template <typename P>
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void ForceSpreading_cic (P const& p,
+                         Real Px, Real Py,
+                         ParticleReal& fxP, ParticleReal& fyP,
+                         ParticleReal& mxP, ParticleReal& myP,
+                         Array4<Real> const& E,
+                         int EulerForceIndex,
+                         Real da,
+                         GpuArray<Real,AMREX_SPACEDIM> const& plo,
+                         GpuArray<Real,AMREX_SPACEDIM> const& dx,
+                         DELTA_FUNCTION_TYPE type)
+{
+    // 坐标计算
+    Real lx = (p.pos(0) - plo[0]) / dx[0];
+    Real ly = (p.pos(1) - plo[1]) / dx[1];
+    int i = static_cast<int>(Math::floor(lx));
+    int j = static_cast<int>(Math::floor(ly));
+
+    // 力乘以面积
+    fxP *= da; fyP *= da;
+    // 循环
+    for(int ii = -2; ii < +3; ii++){
+        for(int jj = -2; jj < +3; jj++){
+            Real tU, tV;
+            const Real xi = plo[0] + (i + ii) * dx[0] + dx[0]/2;
+            const Real yj = plo[1] + (j + jj) * dx[1] + dx[1]/2;
+            deltaFunction(p.pos(0), xi, dx[0], tU, type);
+            deltaFunction(p.pos(1), yj, dx[1], tV, type);
+            Real delta_value = tU * tV;
+            Gpu::Atomic::AddNoRet(&E(i + ii, j + jj, 0, EulerForceIndex  ), delta_value * fxP);
+            Gpu::Atomic::AddNoRet(&E(i + ii, j + jj, 0, EulerForceIndex+1), delta_value * fyP);
+        }
+    }
+}
+
+void mFiber::ForceSpreading(MultiFab & EulerForce, fiber_kernel& kernel, DELTA_FUNCTION_TYPE type)
+{
+    if (verbose) amrex::Print() << "\tmFiber::ForceSpreading\n";
+
+    const auto& gm = mContainer->GetParGDB()->Geom(LOCAL_LEVEL);
+    auto plo = gm.ProbLoArray();
+    auto dxi = gm.CellSizeArray();
+
+    for(mFiberIter pti(*mContainer, LOCAL_LEVEL); pti.isValid(); ++pti){
+        const Long np = pti.numParticles();
+        const auto& particles = pti.GetArrayOfStructs();
+        auto Uarray = EulerForce[pti].array();
+        auto& attri = pti.GetAttribs();
+
+        auto *const fxP_ptr = attri[P_ATTR::Fx_Marker].data();
+        auto *const fyP_ptr = attri[P_ATTR::Fy_Marker].data();
+        auto *const mxP_ptr = attri[P_ATTR::Mx_Marker].data();
+        auto *const myP_ptr = attri[P_ATTR::My_Marker].data();
+        const auto *const p_ptr = particles().data();
+
+        // 细丝系统的中心坐标：使用起点作为参考点
+        auto x0 = kernel.x_marker[0];  // 细丝起点 x 坐标
+        auto y0 = kernel.y_marker[0];  // 细丝起点 y 坐标
+
+        // 细丝系统的面积参数
+        auto da = kernel.da;
+
+        auto force_index = FiberProperties::euler_force_index;
+
+        amrex::ParallelFor(np, [=]
+        AMREX_GPU_DEVICE (int i) noexcept{
+            ForceSpreading_cic(p_ptr[i], x0, y0,
+                               fxP_ptr[i], fyP_ptr[i],
+                               mxP_ptr[i], myP_ptr[i],
+                               Uarray, force_index, da, plo, dxi, type);
+        });
+    }
+
+    // 归约所有处理器的数据
+    using pc = mFiberContainer::SuperParticleType;
+    auto fx = amrex::ReduceSum(*mContainer, [=]AMREX_GPU_HOST_DEVICE(const pc& p)->ParticleReal{
+        return p.rdata(P_ATTR::Fx_Marker);
+    });
+    auto fy = amrex::ReduceSum(*mContainer, [=]AMREX_GPU_HOST_DEVICE(const pc& p)->ParticleReal{
+        return p.rdata(P_ATTR::Fy_Marker);
+    });
+    auto mx = amrex::ReduceSum(*mContainer, [=]AMREX_GPU_HOST_DEVICE(const pc& p)->ParticleReal{
+        return p.rdata(P_ATTR::Mx_Marker);
+    });
+    auto my = amrex::ReduceSum(*mContainer, [=]AMREX_GPU_HOST_DEVICE(const pc& p)->ParticleReal{
+        return p.rdata(P_ATTR::My_Marker);
+    });
+
+    // MPI归约
+    amrex::ParallelAllReduce::Sum(fx, ParallelDescriptor::Communicator());
+    amrex::ParallelAllReduce::Sum(fy, ParallelDescriptor::Communicator());
+    amrex::ParallelAllReduce::Sum(mx, ParallelDescriptor::Communicator());
+    amrex::ParallelAllReduce::Sum(my, ParallelDescriptor::Communicator());
+
+    // 二维下只有x和y方向的力
+    kernel.ib_force = {fx, fy};
+
+    // 边界同步
+    EulerForce.SumBoundary(FiberProperties::euler_force_index, 2, gm.periodicity());
+}
+
+void mFiber::ResetLargrangianPoints()
+{
+    if (verbose) amrex::Print() << "\tmFiber::ResetLargrangianPoints\n";
+
+    for(mFiberIter pti(*mContainer, LOCAL_LEVEL); pti.isValid(); ++pti){
+        const Long np = pti.numParticles();
+        auto& attri = pti.GetAttribs();
+
+        auto *const vUP_ptr = attri[P_ATTR::U_Marker].data();
+        auto *const vVP_ptr = attri[P_ATTR::V_Marker].data();
+        auto *const fxP_ptr = attri[P_ATTR::Fx_Marker].data();
+        auto *const fyP_ptr = attri[P_ATTR::Fy_Marker].data();
+        auto *const mxP_ptr = attri[P_ATTR::Mx_Marker].data();
+        auto *const myP_ptr = attri[P_ATTR::My_Marker].data();
+
+        amrex::ParallelFor(np, [=]
+        AMREX_GPU_DEVICE (int i) noexcept{
+            vUP_ptr[i] = 0.0;
+            vVP_ptr[i] = 0.0;
+
+            fxP_ptr[i] = 0.0;
+            fyP_ptr[i] = 0.0;
+
+            mxP_ptr[i] = 0.0;
+            myP_ptr[i] = 0.0;
+
+        });
+    }
+}
+
+void mFiber::UpdateGeometry(Real time)
+{
+    for(auto& fiber_kernel : fiber_kernels){
+        // 更新每个拉格朗日点的位置和速度
+        for(int i = 0; i < fiber_kernel.num_marker; i++){
+            Real x_pos = fiber_kernel.x_marker[i];
+            Real y_pos = fiber_kernel.y0_base + fiber_kernel.amplitude *
+                        sin(2 * Math::pi<Real>() * (time / fiber_kernel.period - fiber_kernel.wave_number * x_pos / fiber_kernel.length) + fiber_kernel.phase);
+
+            // 更新位置
+            fiber_kernel.y_marker[i] = y_pos;
+
+            // 计算目标速度
+            Real u_b_y = (2 * Math::pi<Real>() * fiber_kernel.amplitude / fiber_kernel.period) *
+                        cos(2 * Math::pi<Real>() * (time / fiber_kernel.period - fiber_kernel.wave_number * x_pos / fiber_kernel.length) + fiber_kernel.phase);
+            fiber_kernel.velocity_marker[i] = RealVect(0.0, u_b_y);
+        }
+
+        fiber_kernel.y_marker_d.resize(fiber_kernel.y_marker.size());
+        amrex::Gpu::copyAsync(amrex::Gpu::hostToDevice,
+                              fiber_kernel.y_marker.begin(), fiber_kernel.y_marker.end(),
+                              fiber_kernel.y_marker_d.begin());
+
+        fiber_kernel.velocity_marker_d.resize(fiber_kernel.velocity_marker.size());
+        amrex::Gpu::copyAsync(amrex::Gpu::hostToDevice,
+                              fiber_kernel.velocity_marker.begin(), fiber_kernel.velocity_marker.end(),
+                              fiber_kernel.velocity_marker_d.begin());
+        amrex::Gpu::streamSynchronize();
+    }
+
+}
+
+void mFiber::UpdateFibers(int iStep, Real time, Real dt)
+{
+    UpdateGeometry(time);
+    int fiber_write_freq = FiberProperties::write_freq;
+    if (iStep % fiber_write_freq == 0) {
+        for(auto& kernel: fiber_kernels)
+            WriteIBForceAndMoment(iStep, time, dt, kernel);
+    }
+    if (verbose) mContainer->WriteAsciiFile(amrex::Concatenate("fiber", 4));
+}
+
+void mFiber::ComputeLagrangianForce(Real dt, const fiber_kernel& kernel)
+{
+    if (verbose) amrex::Print() << "\tmFiber::ComputeLagrangianForce\n";
+
+    for(mFiberIter pti(*mContainer, LOCAL_LEVEL); pti.isValid(); ++pti){
+        const Long np = pti.numParticles();
+        auto& attri = pti.GetAttribs();
+        auto const* p_ptr = pti.GetArrayOfStructs().data();
+
+        auto* Up = attri[P_ATTR::U_Marker].data();
+        auto* Vp = attri[P_ATTR::V_Marker].data();
+        auto *FxP = attri[P_ATTR::Fx_Marker].data();
+        auto *FyP = attri[P_ATTR::Fy_Marker].data();
+        //const RealVect* velocity_marker_ptr = kernel.velocity_marker.data();
+        const RealVect* velocity_marker_ptr = kernel.velocity_marker_d.data();
+
+        // 系数（可改成输入参数）
+        const Real k_pos = 1000.0;
+        const Real k_vel = 1.0;
+        //const Real k_penalty = 1000.0;
+
+        //const Real* xex = kernel.x_marker.data();
+        //const Real* xey = kernel.y_marker.data();
+        const Real* xex = kernel.x_marker_d.data();
+        const Real* xey = kernel.y_marker_d.data();
+        amrex::ParallelFor(np,
+        [=] AMREX_GPU_DEVICE (int i) noexcept{
+// IB力由速度差计算*********************************************************************************
+            //const int id = p_ptr[i].id() - 1; // 粒子 id 从 1 开始，这里转换为 0-based 索引
+            //Real u_b_x = 0.0;
+            //Real u_b_y = fiber_kernel.velocity_marker[i][1]; // 从预计算的速度获取
+            //Real u_b_y = velocity_marker_ptr[id][1]; // 从预计算的速度获取
+            //计算IB力
+            //FxP[i] = (u_b_x - Up[i]) / dt;
+            //FyP[i] = (u_b_y - Vp[i]) / dt;
+
+//由位置差计算IB力*********************************************************************************
+            // X: 当前拉格朗日点位置
+        //    const Real Xx = p_ptr[i].pos(0);
+        //    const Real Xy = p_ptr[i].pos(1);
+
+            // id 从 1 开始
+        //    const int id = p_ptr[i].id() - 1;
+
+            // Xe: 期望位置（由运动公式生成并保存在 kernel.x_marker/y_marker）
+        //    const Real Xex = kernel.x_marker[id];
+        //    const Real Xey = kernel.y_marker[id];
+
+            // F = k (Xe - X)
+        //    FxP[i] = k_penalty * (Xex - Xx);
+        //    FyP[i] = k_penalty * (Xey - Xy);
+//IB力由位置差和速度差共同决定***********************************************************************
+            const int id = p_ptr[i].id() - 1; // 粒子 id 从 1 开始，这里转换为 0-based 索引
+
+            // X（当前真实位置）与 Xe（期望位置）
+            const Real Xx  = p_ptr[i].pos(0);
+            const Real Xy  = p_ptr[i].pos(1);
+            const Real Xex = xex[id];
+            const Real Xey = xey[id];
+
+            // U（插值得到的真实速度）与 Ue（期望速度）
+            const Real Ux  = Up[i];
+            const Real Uy  = Vp[i];
+            const Real Uex = 0.0;
+            const Real Uey = velocity_marker_ptr[id][1];
+
+            // 合成惩罚力：F = k_pos (Xe - X) + k_vel (Ue - U) / dt
+            FxP[i] = k_pos * (Xex - Xx) / dt + k_vel * (Uex - Ux) / dt;
+            FyP[i] = k_pos * (Xey - Xy) / dt + k_vel * (Uey - Uy) / dt;
+        });
+    }
+    if (verbose) mContainer->WriteAsciiFile(amrex::Concatenate("fiber", 3));
+}
+
+void mFiber::VelocityCorrection(amrex::MultiFab &Euler, amrex::MultiFab &EulerForce, Real dt) const
+{
+    if(verbose) amrex::Print() << "\tmFiber::VelocityCorrection\n";
+
+    // 速度修正
+    MultiFab::Saxpy(Euler, dt, EulerForce, FiberProperties::euler_force_index, FiberProperties::euler_velocity_index, 2, 0);
+
+}
+
+void mFiber::WriteFiberFile(int index)
+{
+    mContainer->WriteAsciiFile(amrex::Concatenate("fiber", index));
+}
+
+void mFiber::WriteIBForceAndMoment(int step, amrex::Real time, amrex::Real dt, fiber_kernel& current_kernel)
+{
+    if(amrex::ParallelDescriptor::MyProc() != ParallelDescriptor::IOProcessorNumber()) return;
+
+    std::string file("IB_Fiber_" + std::to_string(current_kernel.id) + ".csv");
+    std::ofstream out_ib_force;
+
+    std::string head;
+    if(!fs::exists(file)){
+        head = "iStep,time,Fx,Fy\n";
+    }else{
+        head = "";
+    }
+
+    out_ib_force.open(file, std::ios::app);
+    if(!out_ib_force.is_open()){
+        amrex::Print() << "[Fiber] write fiber file error , step: " << step;
+    }else{
+        out_ib_force << head << step << "," << time << ","
+                     << current_kernel.ib_force[0] << "," << current_kernel.ib_force[1] << "\n";
+    }
+    out_ib_force.close();
+}
+
+void Fibers::create_fibers(const Geometry &gm,
+                           const DistributionMapping &dm,
+                           const BoxArray &ba)
+{
+    amrex::Print() << "[Fiber] : create Fiber Container\n";
+    if (fiber->mContainer != nullptr) {
+        delete fiber->mContainer;
+        fiber->mContainer = nullptr;
+    }
+    fiber->mContainer = new mFiberContainer(gm, dm, ba);
+
+    // 获取fiber tile
+    std::pair<int, int> key{0, 0};
+    auto& fiberTileTmp = fiber->mContainer->GetParticles(0)[key];
+
+    // 插入fiber节点
+    if (ParallelDescriptor::MyProc() == ParallelDescriptor::IOProcessorNumber()) {
+        for (int fiber_index = 0; fiber_index < fiber->fiber_kernels[0].num_marker; ++fiber_index) {
+            mFiberContainer::ParticleType fiberNode;
+            fiberNode.id() = fiber_index + 1;
+            fiberNode.cpu() = ParallelDescriptor::MyProc();
+            fiberNode.pos(0) = fiber->fiber_kernels[0].x_marker[fiber_index];
+            fiberNode.pos(1) = fiber->fiber_kernels[0].y_marker[fiber_index];
+            //fiberNode.pos(2) = 0.0; // 二维细丝，z坐标为0
+
+            std::array<ParticleReal, numAttri> Fiber_attr{};
+            Fiber_attr[U_Marker] = fiber->fiber_kernels[0].velocity_marker[fiber_index][0];
+            Fiber_attr[V_Marker] = fiber->fiber_kernels[0].velocity_marker[fiber_index][1];
+            Fiber_attr[W_Marker] = 0.0; // 二维细丝，W分量为0
+            Fiber_attr[Fx_Marker] = 0.0;
+            Fiber_attr[Fy_Marker] = 0.0;
+            Fiber_attr[Fz_Marker] = 0.0; // 二维细丝，Fz分量为0
+
+            fiberTileTmp.push_back(fiberNode);
+            fiberTileTmp.push_back_real(Fiber_attr);
+        }
+    }
+    fiber->mContainer->Redistribute();
+
+    //FiberProperties::plo = gm.ProbLoArray();
+    auto prob_lo = gm.ProbLoArray();
+    FiberProperties::plo = amrex::GpuArray<Real,2>{prob_lo[0], prob_lo[1]};
+    //FiberProperties::phi = gm.ProbHiArray();
+    auto prob_hi = gm.ProbHiArray();
+    FiberProperties::phi = amrex::GpuArray<Real,2>{prob_hi[0], prob_hi[1]};
+    //FiberProperties::dx = gm.CellSizeArray();
+    auto cell_size = gm.CellSizeArray();
+    FiberProperties::dx = amrex::GpuArray<Real,2>{cell_size[0], cell_size[1]};
+}
+mFiber* Fibers::get_fibers()
+{
+    return fiber;
+}
+
+void Fibers::init_fiber(Real gravity, Real h)
+{
+    amrex::Print() << "[Fiber] : create Fiber's kernel\n";
+    fiber = new mFiber;
+    if (fiber != nullptr) {
+        isInitial = true;
+        fiber->InitFibers(
+            FiberProperties::x0,
+            FiberProperties::y0,
+            FiberProperties::amplitude,
+            FiberProperties::period,
+            FiberProperties::length,
+            FiberProperties::wave_number,
+            FiberProperties::phase,
+            FiberProperties::num_marker,
+            h,
+            FiberProperties::verbose);
+    }
+}
+
+void Fibers::Initialize()
+{
+    ParmParse pp("fiber");
+
+    std::string fiber_inputfile;
+    pp.get("input", fiber_inputfile);
+
+    if(!fiber_inputfile.empty()){
+        ParmParse p_file(fiber_inputfile);
+        p_file.getarr("x0",          FiberProperties::x0);
+        p_file.getarr("y0",          FiberProperties::y0);
+        p_file.getarr("amplitude",   FiberProperties::amplitude);
+        p_file.getarr("period",      FiberProperties::period);
+        p_file.getarr("length",      FiberProperties::length);
+        p_file.getarr("wave_number", FiberProperties::wave_number);
+        p_file.getarr("phase",       FiberProperties::phase);
+        p_file.getarr("num_marker",  FiberProperties::num_marker);
+        p_file.query("verbose",      FiberProperties::verbose);
+        p_file.query("start_step",   FiberProperties::start_step);
+        p_file.query("write_freq",   FiberProperties::write_freq);
+        p_file.query("LOOP_NS",      FiberProperties::loop_ns);
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(FiberProperties::loop_ns > 0
+                                        && FiberProperties::write_freq > 0,
+            "fiber LOOP_NS and write_freq must be positive");
+
+        ParmParse ns("ns");
+        ns.get("fluid_rho",          FiberProperties::euler_fluid_rho);
+
+        ParmParse level_parse("amr");
+        level_parse.get("max_level", FiberProperties::euler_finest_level);
+
+        ParmParse geometry_parse("geometry");
+        geometry_parse.getarr("prob_lo", FiberProperties::GLO);
+        geometry_parse.getarr("prob_hi", FiberProperties::GHI);
+
+        amrex::Print() << "[Fiber] : Reading fiber cfg file : " << fiber_inputfile << "\n"
+                       << "             Fiber's level : " << FiberProperties::euler_finest_level << "\n";
+
+    }else {
+        amrex::Abort("[Fiber] : can't read fiber settings, pls check your config file \"fiber.input\"");
+    }
+}
+
+int Fibers::FiberFinestLevel()
+{
+    return FiberProperties::euler_finest_level;
+}
+
+#endif

--- a/Source/DiffusedIB.H
+++ b/Source/DiffusedIB.H
@@ -13,7 +13,9 @@
 #include <AMReX_RealVect.H>
 #include <fstream>
 
+#if (AMREX_SPACEDIM == 3)
 #include "Collision.H"
+#endif
 using namespace amrex;
 // using deltaFuncType = std::function<AMREX_GPU_HOST_DEVICE void(Real, Real, Real, Real&)>;
 
@@ -52,6 +54,7 @@ enum DELTA_FUNCTION_TYPE{
     THREE_POINT_IB
 };
 
+#if (AMREX_SPACEDIM == 3)
 struct kernel{
     int id;
     RealVect velocity{0.0,0.0,0.0};
@@ -66,7 +69,7 @@ struct kernel{
     Real radius{0.0};
     Real radius2{0.0};
     Real radius3{0.0};
-    int geometry_type{1};  // 1 = sphere, 2 = ellipsoid; any other value aborts
+    int geometry_type{1};  // 1 = sphere, 2 = ellipsoid, 3 = prescribed traveling-wave fin
     Real rho{0.0};
     int ml{0};
     Real dv{0.0};
@@ -86,6 +89,18 @@ struct kernel{
     amrex::Gpu::DeviceVector<Real> thetaK;
 
     IntVect TL{0, 0, 0}, RL{0, 0, 0};
+
+    // Prescribed traveling-wave fin.  The reference surface is
+    // X(s,r,0) = location + (s,r,0), with 0<=s<=length and 0<=r<=span.
+    Real fin_length{0.0};
+    Real fin_span{0.0};
+    Real fin_amplitude{0.0};       // radians
+    Real fin_frequency{0.0};       // Hz
+    Real fin_wavelength{0.0};
+    Real fin_phase{0.0};           // radians
+    Real fin_marker_thickness{0.0};
+    int fin_n_chord{0};
+    int fin_n_span{0};
 };
 
 class mParIter : public ParIter<0, 0, numAttri>{
@@ -143,7 +158,10 @@ public:
                        Real gravity,
                        int verbose = 0);
 
-    void InteractWithEuler(MultiFab &EulerVel, MultiFab &EulerForce, Real dt = 0.1, DELTA_FUNCTION_TYPE type = FOUR_POINT_IB);
+    void InteractWithEuler(MultiFab &EulerVel, MultiFab &EulerForce,
+                           Real dt = 0.1,
+                           DELTA_FUNCTION_TYPE type = FOUR_POINT_IB,
+                           Real boundary_time = 0.0);
 
     void WriteParticleFile(int index);
 
@@ -159,11 +177,16 @@ public:
 
     void VelocityCorrection(amrex::MultiFab &Euler, amrex::MultiFab &EulerForce, Real dt) const;
 
-    void UpdateParticles(int iStep, Real time, const MultiFab& Euler_old, const MultiFab& Euler, MultiFab& phi_nodal, MultiFab& pvf, Real dt);
+    void UpdateParticles(int iStep, int finestStep, Real time,
+                         const MultiFab& Euler_old, const MultiFab& Euler,
+                         MultiFab& phi_nodal, MultiFab& pvf, Real dt);
 
     void DoParticleCollision(int model);
 
     static void WriteIBForceAndMoment(int step, amrex::Real time, amrex::Real dt, kernel& current_kernel);
+
+    static void WriteFinVTK(int step, amrex::Real time, const kernel& current_kernel,
+                            const std::string& output_dir = "");
 
     void RecordOldValue(kernel& kernel);
 
@@ -182,6 +205,8 @@ public:
     int verbose = 0;
 
     Real spend_time;
+
+    Real ib_time{0.0};
 };
 
 class Particles{
@@ -209,5 +234,7 @@ public:
 private:
     inline static mParticle* particle = nullptr;
 };
+
+#endif // AMREX_SPACEDIM == 3
 
 #endif

--- a/Source/DiffusedIB.cpp
+++ b/Source/DiffusedIB.cpp
@@ -15,6 +15,7 @@
 #include <iamr_constants.H>
 
 #include <filesystem>
+#include <iomanip>
 #include <sstream>
 namespace fs = std::filesystem;
 
@@ -54,6 +55,16 @@ namespace ParticleProperties{
 
     int write_freq{1};
     bool init_particle_from_file{false};
+
+    // geometry_type=3: prescribed traveling-wave fin parameters.
+    Real fin_length{0.0};
+    Real fin_span{0.0};
+    Real fin_amplitude_deg{0.0};
+    Real fin_frequency{0.0};
+    Real fin_wavelength{0.0};
+    Real fin_phase{0.0};
+    int fin_n_chord{0};
+    int fin_n_span{0};
 
     GpuArray<Real, 3> plo{0.0,0.0,0.0}, phi{0.0,0.0,0.0}, dx{0.0, 0.0, 0.0};
 }
@@ -103,10 +114,8 @@ void nodal_phi_to_pvf(MultiFab& pvf, const MultiFab& phi_nodal)
 
 }
 
-// Fill phi_nodal with the nodal level set of a single particle: negative inside
-// the body, positive outside. Handles geometry_type = 1 (sphere, signed distance
-// normalised by the radius) and geometry_type = 2 (ellipsoid, a first-order
-// approximation that is deliberately left unnormalised). Any other value aborts.
+// Nodal level set for closed rigid bodies (sphere or ellipsoid).
+// Prescribed fins bypass this volume calculation in UpdateParticles.
 void calculate_phi_nodal(MultiFab& phi_nodal, kernel& current_kernel)
 {
     phi_nodal.setVal(0.0);
@@ -326,11 +335,13 @@ void deltaFunction(Real xf, Real xp, Real h, Real& value, DELTA_FUNCTION_TYPE ty
 void mParticle::InteractWithEuler(MultiFab &EulerVel,
                                   MultiFab &EulerForce,
                                   Real dt,
-                                  DELTA_FUNCTION_TYPE type)
+                                  DELTA_FUNCTION_TYPE type,
+                                  Real boundary_time)
 {
     if (verbose) amrex::Print() << "[Particle] mParticle::InteractWithEuler\n";
     // clear time , start record
     spend_time = 0;
+    ib_time = boundary_time;
     auto InteractWithEulerStart = ParallelDescriptor::second();
 
     MultiFab EulerForceTmp(EulerForce.boxArray(), EulerForce.DistributionMap(), 3, EulerForce.nGrow());
@@ -462,6 +473,46 @@ void mParticle::InitParticles(const Vector<Real>& x,
         }
         mKernel.Vp = Math::pi<Real>() * 4 / 3 * Math::powi<3>(radius[real_index]);
 
+        if (mKernel.geometry_type == 3) {
+            AMREX_ALWAYS_ASSERT_WITH_MESSAGE(ParticleProperties::fin_length > 0.0,
+                "traveling-wave fin requires fin_length > 0");
+            AMREX_ALWAYS_ASSERT_WITH_MESSAGE(ParticleProperties::fin_span > 0.0,
+                "traveling-wave fin requires fin_span > 0");
+            AMREX_ALWAYS_ASSERT_WITH_MESSAGE(ParticleProperties::fin_wavelength > 0.0,
+                "traveling-wave fin requires fin_wavelength > 0");
+            AMREX_ALWAYS_ASSERT_WITH_MESSAGE(ParticleProperties::fin_n_chord >= 2 && ParticleProperties::fin_n_span >= 2,
+                "traveling-wave fin requires fin_n_chord and fin_n_span >= 2");
+
+            mKernel.fin_length = ParticleProperties::fin_length;
+            mKernel.fin_span = ParticleProperties::fin_span;
+            mKernel.fin_amplitude = ParticleProperties::fin_amplitude_deg * Math::pi<Real>() / 180.0;
+            mKernel.fin_frequency = ParticleProperties::fin_frequency;
+            mKernel.fin_wavelength = ParticleProperties::fin_wavelength;
+            mKernel.fin_phase = ParticleProperties::fin_phase;
+            mKernel.fin_n_chord = ParticleProperties::fin_n_chord;
+            mKernel.fin_n_span = ParticleProperties::fin_n_span;
+            mKernel.fin_marker_thickness = h;
+            mKernel.ml = mKernel.fin_n_chord * mKernel.fin_n_span;
+            mKernel.dv = h * mKernel.fin_length / (mKernel.fin_n_chord - 1)
+                           * mKernel.fin_span / (mKernel.fin_n_span - 1);
+            mKernel.Vp = 0.0;
+            if (mKernel.ml > max_largrangian_num) max_largrangian_num = mKernel.ml;
+            particle_kernels.emplace_back(mKernel);
+
+            if (verbose) {
+                amrex::Print() << "Fin kernel " << mKernel.id
+                               << ": origin=(" << mKernel.location[0] << ","
+                               << mKernel.location[1] << "," << mKernel.location[2] << ")"
+                               << ", length=" << mKernel.fin_length
+                               << ", span=" << mKernel.fin_span
+                               << ", markers=" << mKernel.fin_n_chord << "x" << mKernel.fin_n_span
+                               << ", amplitude(rad)=" << mKernel.fin_amplitude
+                               << ", frequency=" << mKernel.fin_frequency
+                               << ", wavelength=" << mKernel.fin_wavelength << "\n";
+            }
+            continue;
+        }
+
         //int Ml = static_cast<int>( Math::pi<Real>() / 3 * (12 * Math::powi<2>(mKernel.radius / h)));
         //Real dv = Math::pi<Real>() * h / 3 / Ml * (12 * mKernel.radius * mKernel.radius + h * h);
         int Ml = static_cast<int>((amrex::Math::powi<3>(mKernel.radius - (ParticleProperties::rd - 0.5) * h)
@@ -506,15 +557,39 @@ void mParticle::InitialWithLargrangianPoints(const kernel& current_kernel){
 
         const auto location = current_kernel.location;
         const auto radius = current_kernel.radius;
+        const auto geometry_type = current_kernel.geometry_type;
         const auto* phiK = current_kernel.phiK.dataPtr();
         const auto* thetaK = current_kernel.thetaK.dataPtr();
+        const auto fin_length = current_kernel.fin_length;
+        const auto fin_span = current_kernel.fin_span;
+        const auto fin_amplitude = current_kernel.fin_amplitude;
+        const auto fin_frequency = current_kernel.fin_frequency;
+        const auto fin_wavelength = current_kernel.fin_wavelength;
+        const auto fin_phase = current_kernel.fin_phase;
+        const auto fin_n_chord = current_kernel.fin_n_chord;
+        const auto fin_n_span = current_kernel.fin_n_span;
+        const auto time = ib_time;
 
         amrex::ParallelFor( np, [=]
             AMREX_GPU_DEVICE (int i) noexcept {
                 auto id = particles[i].id();
-                particles[i].pos(0) = location[0] + radius * std::sin(thetaK[id - 1]) * std::cos(phiK[id - 1]);
-                particles[i].pos(1) = location[1] + radius * std::sin(thetaK[id - 1]) * std::sin(phiK[id - 1]);
-                particles[i].pos(2) = location[2] + radius * std::cos(thetaK[id - 1]);
+                if (geometry_type == 3) {
+                    const int local_id = static_cast<int>(id - 1);
+                    const int chord_id = local_id / fin_n_span;
+                    const int span_id = local_id - chord_id * fin_n_span;
+                    const Real s = fin_length * chord_id / Real(fin_n_chord - 1);
+                    const Real r = fin_span * span_id / Real(fin_n_span - 1);
+                    const Real theta = fin_amplitude * std::sin(
+                        2.0 * Math::pi<Real>() * fin_frequency * time
+                        - 2.0 * Math::pi<Real>() * s / fin_wavelength + fin_phase);
+                    particles[i].pos(0) = location[0] + s;
+                    particles[i].pos(1) = location[1] + r * std::cos(theta);
+                    particles[i].pos(2) = location[2] + r * std::sin(theta);
+                } else {
+                    particles[i].pos(0) = location[0] + radius * std::sin(thetaK[id - 1]) * std::cos(phiK[id - 1]);
+                    particles[i].pos(1) = location[1] + radius * std::sin(thetaK[id - 1]) * std::sin(phiK[id - 1]);
+                    particles[i].pos(2) = location[2] + radius * std::cos(thetaK[id - 1]);
+                }
             }
         );
     }
@@ -695,13 +770,25 @@ void mParticle::ForceSpreading(MultiFab & EulerForce,
 
         auto loc_ptr = kernel.location;
         auto dv = kernel.dv;
+        const auto geometry_type = kernel.geometry_type;
+        const auto fin_n_chord = kernel.fin_n_chord;
+        const auto fin_n_span = kernel.fin_n_span;
         auto force_index = ParticleProperties::euler_force_index;
         amrex::ParallelFor(np, [=]
         AMREX_GPU_DEVICE (int i) noexcept{
+            Real marker_volume = dv;
+            if (geometry_type == 3) {
+                const int local_id = static_cast<int>(p_ptr[i].id() - 1);
+                const int chord_id = local_id / fin_n_span;
+                const int span_id = local_id - chord_id * fin_n_span;
+                const Real chord_weight = (chord_id == 0 || chord_id == fin_n_chord - 1) ? 0.5 : 1.0;
+                const Real span_weight = (span_id == 0 || span_id == fin_n_span - 1) ? 0.5 : 1.0;
+                marker_volume *= chord_weight * span_weight;
+            }
             ForceSpreading_cic(p_ptr[i], loc_ptr[0], loc_ptr[1], loc_ptr[2],
                                fxP_ptr[i], fyP_ptr[i], fzP_ptr[i],
                                mxP_ptr[i], myP_ptr[i], mzP_ptr[i],
-                               Uarray, force_index, dv, plo, dxi, type);
+                               Uarray, force_index, marker_volume, plo, dxi, type);
         });
     }
     //barrier for sync;
@@ -794,6 +881,7 @@ void mParticle::ResetLargrangianPoints()
 }
 
 void mParticle::UpdateParticles(int iStep,
+                                int finestStep,
                                 Real time,
                                 const MultiFab& Euler_old,
                                 const MultiFab& Euler,
@@ -813,6 +901,15 @@ void mParticle::UpdateParticles(int iStep,
 
     //continue condition 6DOF
     for(auto& kernel : particle_kernels){
+
+        // A prescribed zero-thickness fin is coupled only through its
+        // Lagrangian surface.  It has no closed volume for PVF and does not
+        // participate in collision or rigid-body (6-DOF) advancement.
+        if (kernel.geometry_type == 3) {
+            phi_nodal.setVal(1.0);
+            pvf.setVal(0.0);
+            continue;
+        }
 
         calculate_phi_nodal(phi_nodal, kernel);
         nodal_phi_to_pvf(pvf, phi_nodal);
@@ -945,17 +1042,31 @@ void mParticle::UpdateParticles(int iStep,
     amrex::Print() << "[DIBM] IB and update particle, step : "<< iStep <<", time : " << spend_time << "\n";
 
     int particle_write_freq = ParticleProperties::write_freq;
-    if (iStep % particle_write_freq == 0) {
-        for(auto kernel: particle_kernels)
-            WriteIBForceAndMoment(iStep, time, dt, kernel);
+    for (auto kernel : particle_kernels) {
+        // Under AMR subcycling the prescribed fin advances on the finest
+        // level.  Use that level's step counter so write_freq keeps its
+        // original fine-step meaning.  Rigid-particle output remains tied to
+        // the coarse step for backward compatibility.
+        const int output_step = kernel.geometry_type == 3 ? finestStep : iStep;
+        if (output_step % particle_write_freq == 0) {
+            WriteIBForceAndMoment(output_step,
+                                  kernel.geometry_type == 3 ? time + dt : time,
+                                  dt, kernel);
+        }
     }
-
     if (verbose) mContainer->WriteAsciiFile(amrex::Concatenate("particle", 4));
 }
 
 void mParticle::DoParticleCollision(int model)
 {
     if(particle_kernels.size() < 2 ) return ;
+
+    // Prescribed surfaces have no collision model in this first-stage fin
+    // implementation.  Do not pass their placeholder radius to the rigid
+    // particle collision system in a mixed configuration.
+    for (const auto& particle_kernel : particle_kernels) {
+        if (particle_kernel.geometry_type == 3) return;
+    }
 
     if (verbose) amrex::Print() << "\tmParticle::DoParticleCollision\n";
 
@@ -990,6 +1101,16 @@ void mParticle::ComputeLagrangianForce(Real dt,
     Real Py = kernel.location[1];
     Real Pz = kernel.location[2];
     RealVect omega_local = kernel.omega;
+    const auto geometry_type = kernel.geometry_type;
+    const auto fin_span = kernel.fin_span;
+    const auto fin_length = kernel.fin_length;
+    const auto fin_amplitude = kernel.fin_amplitude;
+    const auto fin_frequency = kernel.fin_frequency;
+    const auto fin_wavelength = kernel.fin_wavelength;
+    const auto fin_phase = kernel.fin_phase;
+    const auto fin_n_chord = kernel.fin_n_chord;
+    const auto fin_n_span = kernel.fin_n_span;
+    const auto time = ib_time;
 
     for(mParIter pti(*mContainer, LOCAL_LEVEL); pti.isValid(); ++pti){
         const Long np = pti.numParticles();
@@ -1005,10 +1126,32 @@ void mParticle::ComputeLagrangianForce(Real dt,
 
         amrex::ParallelFor(np,
         [=] AMREX_GPU_DEVICE (int i) noexcept{
-            auto Ur = omega_local.crossProduct(RealVect(p_ptr[i].pos(0) - Px, p_ptr[i].pos(1) - Py, p_ptr[i].pos(2) - Pz));
-            FxP[i] = (Ub + Ur[0] - Up[i])/dt; //
-            FyP[i] = (Vb + Ur[1] - Vp[i])/dt; //
-            FzP[i] = (Wb + Ur[2] - Wp[i])/dt; //
+            Real target_u = Ub;
+            Real target_v = Vb;
+            Real target_w = Wb;
+            if (geometry_type == 3) {
+                const int local_id = static_cast<int>(p_ptr[i].id() - 1);
+                const int chord_id = local_id / fin_n_span;
+                const int span_id = local_id - chord_id * fin_n_span;
+                const Real s = fin_length * chord_id / Real(fin_n_chord - 1);
+                const Real r = fin_span * span_id / Real(fin_n_span - 1);
+                const Real argument = 2.0 * Math::pi<Real>() * fin_frequency * time
+                                    - 2.0 * Math::pi<Real>() * s / fin_wavelength + fin_phase;
+                const Real theta = fin_amplitude * std::sin(argument);
+                const Real theta_dot = 2.0 * Math::pi<Real>() * fin_frequency
+                                     * fin_amplitude * std::cos(argument);
+                target_u = 0.0;
+                target_v = -r * std::sin(theta) * theta_dot;
+                target_w =  r * std::cos(theta) * theta_dot;
+            } else {
+                auto Ur = omega_local.crossProduct(RealVect(p_ptr[i].pos(0) - Px, p_ptr[i].pos(1) - Py, p_ptr[i].pos(2) - Pz));
+                target_u += Ur[0];
+                target_v += Ur[1];
+                target_w += Ur[2];
+            }
+            FxP[i] = (target_u - Up[i])/dt;
+            FyP[i] = (target_v - Vp[i])/dt;
+            FzP[i] = (target_w - Wp[i])/dt;
         });
     }
     if (verbose) mContainer->WriteAsciiFile(amrex::Concatenate("particle", 3));
@@ -1036,6 +1179,32 @@ void mParticle::WriteIBForceAndMoment(int step, amrex::Real time, amrex::Real dt
 {
 
     if(amrex::ParallelDescriptor::MyProc() != ParallelDescriptor::IOProcessorNumber()) return;
+
+    if (current_kernel.geometry_type == 3) {
+        const std::string file("IB_Fin_" + std::to_string(current_kernel.id) + ".csv");
+        const bool new_file = !fs::exists(file);
+        std::ofstream out(file, std::ios::app);
+        if (!out.is_open()) {
+            amrex::Print() << "[DIBM] cannot open fin force file " << file << "\n";
+            return;
+        }
+        if (new_file) {
+            out << "step,time,phase,Fx,Fy,Fz,Mx,My,Mz\n";
+        }
+        const Real phase = 2.0 * Math::pi<Real>() * current_kernel.fin_frequency * time
+                         + current_kernel.fin_phase;
+        // Marker force is the acceleration applied to the fluid.  Multiplying
+        // by rho gives force; the minus sign gives fluid-on-fin load.
+        const Real rho = ParticleProperties::euler_fluid_rho;
+        out << step << "," << time << "," << phase << ","
+            << -rho * current_kernel.ib_force[0] << ","
+            << -rho * current_kernel.ib_force[1] << ","
+            << -rho * current_kernel.ib_force[2] << ","
+            << -rho * current_kernel.ib_moment[0] << ","
+            << -rho * current_kernel.ib_moment[1] << ","
+            << -rho * current_kernel.ib_moment[2] << "\n";
+        return;
+    }
 
     std::string file("IB_Particle_" + std::to_string(current_kernel.id) + ".csv");
     std::ofstream out_ib_force;
@@ -1069,6 +1238,85 @@ void mParticle::WriteIBForceAndMoment(int step, amrex::Real time, amrex::Real dt
     out_ib_force.close();
 }
 
+void mParticle::WriteFinVTK(int step, amrex::Real time, const kernel& current_kernel,
+                            const std::string& output_dir)
+{
+    if (amrex::ParallelDescriptor::MyProc() != ParallelDescriptor::IOProcessorNumber()) return;
+    if (current_kernel.geometry_type != 3) return;
+
+    const int nc = current_kernel.fin_n_chord;
+    const int nr = current_kernel.fin_n_span;
+    const int npoints = nc * nr;
+    const int ntriangles = 2 * (nc - 1) * (nr - 1);
+    const std::string prefix = current_kernel.id == 1
+                             ? "fin_"
+                             : "fin_" + std::to_string(current_kernel.id) + "_";
+    const std::string base_name = amrex::Concatenate(prefix, step, 8) + ".vtk";
+
+    if (!output_dir.empty()) {
+        std::error_code ec;
+        fs::create_directories(output_dir, ec);
+        if (ec) {
+            amrex::Print() << "[DIBM] cannot create fin VTK directory "
+                           << output_dir << ": " << ec.message() << "\n";
+            return;
+        }
+    }
+    const std::string file = output_dir.empty() ? base_name
+                                                 : output_dir + "/" + base_name;
+    std::ofstream out(file);
+    if (!out.is_open()) {
+        amrex::Print() << "[DIBM] cannot open fin VTK file " << file << "\n";
+        return;
+    }
+
+    out << "# vtk DataFile Version 3.0\n"
+        << "IAMReX prescribed traveling-wave fin, time=" << time << "\n"
+        << "ASCII\n"
+        << "DATASET POLYDATA\n"
+        << "POINTS " << npoints << " double\n"
+        << std::setprecision(16);
+
+    for (int ic = 0; ic < nc; ++ic) {
+        const Real s = current_kernel.fin_length * ic / Real(nc - 1);
+        const Real argument = 2.0 * Math::pi<Real>() * current_kernel.fin_frequency * time
+                            - 2.0 * Math::pi<Real>() * s / current_kernel.fin_wavelength
+                            + current_kernel.fin_phase;
+        const Real theta = current_kernel.fin_amplitude * std::sin(argument);
+        for (int ir = 0; ir < nr; ++ir) {
+            const Real r = current_kernel.fin_span * ir / Real(nr - 1);
+            out << current_kernel.location[0] + s << " "
+                << current_kernel.location[1] + r * std::cos(theta) << " "
+                << current_kernel.location[2] + r * std::sin(theta) << "\n";
+        }
+    }
+
+    out << "POLYGONS " << ntriangles << " " << 4 * ntriangles << "\n";
+    for (int ic = 0; ic < nc - 1; ++ic) {
+        for (int ir = 0; ir < nr - 1; ++ir) {
+            const int p0 = ic * nr + ir;
+            const int p1 = p0 + 1;
+            const int p2 = (ic + 1) * nr + ir;
+            const int p3 = p2 + 1;
+            out << "3 " << p0 << " " << p1 << " " << p2 << "\n";
+            out << "3 " << p1 << " " << p3 << " " << p2 << "\n";
+        }
+    }
+
+    const Real rho = ParticleProperties::euler_fluid_rho;
+    out << "FIELD FieldData 4\n"
+        << "step 1 1 int\n" << step << "\n"
+        << "time 1 1 double\n" << time << "\n"
+        << "fluid_on_fin_force 3 1 double\n"
+        << -rho * current_kernel.ib_force[0] << " "
+        << -rho * current_kernel.ib_force[1] << " "
+        << -rho * current_kernel.ib_force[2] << "\n"
+        << "fluid_on_fin_moment 3 1 double\n"
+        << -rho * current_kernel.ib_moment[0] << " "
+        << -rho * current_kernel.ib_moment[1] << " "
+        << -rho * current_kernel.ib_moment[2] << "\n";
+}
+
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                    Particles member function                  */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -1100,12 +1348,7 @@ void Particles::create_particles(const Geometry &gm,
             markerP.pos(2) = particle->particle_kernels[0].location[2];
 
             std::array<ParticleReal, numAttri> Marker_attr;
-            Marker_attr[U_Marker] = 0.0;
-            Marker_attr[V_Marker] = 0.0;
-            Marker_attr[W_Marker] = 0.0;
-            Marker_attr[Fx_Marker] = 0.0;
-            Marker_attr[Fy_Marker] = 0.0;
-            Marker_attr[Fz_Marker] = 0.0;
+            Marker_attr.fill(0.0);
 
             particleTileTmp.push_back(markerP);
             particleTileTmp.push_back_real(Marker_attr);
@@ -1192,6 +1435,9 @@ void Particles::Restart(Real gravity, Real h, int iStep)
     //deal in IO processor
     //start read csv file
     for(auto& kernel : particle->particle_kernels){
+        // Prescribed fin state is an analytic function of checkpoint time;
+        // there is no rigid-body state to recover from a particle CSV file.
+        if (kernel.geometry_type == 3) continue;
         //filename
         if(amrex::ParallelDescriptor::MyProc() == amrex::ParallelDescriptor::IOProcessorNumber()){
             std::string fileName = "IB_Particle_" + std::to_string(kernel.id) + ".csv";
@@ -1294,6 +1540,14 @@ void Particles::Initialize()
         p_file.query("Uhlmann",     ParticleProperties::Uhlmann);
         p_file.query("collision_model", ParticleProperties::collision_model);
         p_file.query("write_freq",  ParticleProperties::write_freq);
+        p_file.query("fin_length",        ParticleProperties::fin_length);
+        p_file.query("fin_span",          ParticleProperties::fin_span);
+        p_file.query("fin_amplitude_deg", ParticleProperties::fin_amplitude_deg);
+        p_file.query("fin_frequency",     ParticleProperties::fin_frequency);
+        p_file.query("fin_wavelength",    ParticleProperties::fin_wavelength);
+        p_file.query("fin_phase",         ParticleProperties::fin_phase);
+        p_file.query("fin_n_chord",       ParticleProperties::fin_n_chord);
+        p_file.query("fin_n_span",        ParticleProperties::fin_n_span);
 
         ParmParse ns("ns");
         ns.get("fluid_rho",      ParticleProperties::euler_fluid_rho);

--- a/Source/Make.package
+++ b/Source/Make.package
@@ -44,13 +44,18 @@ CEXE_sources += NS_LS.cpp
 CEXE_headers += NS_LS.H
 
 ifeq ($(USE_PARTICLES), TRUE)
-  ifeq ($(PARTICLE_PARALLEL), TRUE)
-    CEXE_sources += DiffusedIB_Parallel.cpp
-    CEXE_headers += DiffusedIB_Parallel.H
+  ifeq ($(DIM), 2)
+    CEXE_sources += DiffusedFiber.cpp
+    CEXE_headers += DiffusedFiber.H DiffusedIB.H
   else
-    CEXE_sources += DiffusedIB.cpp
-    CEXE_headers += DiffusedIB.H
+    ifeq ($(PARTICLE_PARALLEL), TRUE)
+      CEXE_sources += DiffusedIB_Parallel.cpp
+      CEXE_headers += DiffusedIB_Parallel.H
+    else
+      CEXE_sources += DiffusedIB.cpp
+      CEXE_headers += DiffusedIB.H
+    endif
+    CEXE_sources += Collision.cpp
+    CEXE_headers += Collision.H
   endif
-  CEXE_sources += Collision.cpp
-  CEXE_headers += Collision.H
 endif

--- a/Source/NS_derive.H
+++ b/Source/NS_derive.H
@@ -36,6 +36,12 @@ namespace derive_functions {
           const amrex::FArrayBox& datfab, const amrex::Geometry& geomdata,
           amrex::Real time, const int* bcrec, int level);
   //
+  // Compute the magnitude of the cell-centered velocity vector
+  //
+  void dermagvel (const amrex::Box& bx, amrex::FArrayBox& derfab, int dcomp, int ncomp,
+          const amrex::FArrayBox& datfab, const amrex::Geometry& geomdata,
+          amrex::Real time, const int* bcrec, int level);
+  //
   // Compute kinetic energy
   //
   void derkeng (const amrex::Box& bx, amrex::FArrayBox& derfab, int dcomp, int ncomp,

--- a/Source/NS_derive.cpp
+++ b/Source/NS_derive.cpp
@@ -12,6 +12,30 @@ using namespace amrex;
 
 namespace derive_functions
 {
+  void dermagvel (const Box& bx, FArrayBox& derfab, int dcomp, int ncomp,
+          const FArrayBox& datfab, const Geometry& /*geomdata*/,
+          Real /*time*/, const int* /*bcrec*/, int /*level*/)
+  {
+    AMREX_ASSERT(derfab.box().contains(bx));
+    AMREX_ASSERT(datfab.box().contains(bx));
+    AMREX_ASSERT(derfab.nComp() >= dcomp + ncomp);
+    AMREX_ASSERT(datfab.nComp() >= AMREX_SPACEDIM);
+    AMREX_ASSERT(ncomp == 1);
+
+    const auto vel = datfab.const_array();
+    const auto mag = derfab.array(dcomp);
+
+    amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+    {
+      amrex::Real mag_sq = vel(i,j,k,0) * vel(i,j,k,0)
+                         + vel(i,j,k,1) * vel(i,j,k,1);
+#if (AMREX_SPACEDIM == 3)
+      mag_sq += vel(i,j,k,2) * vel(i,j,k,2);
+#endif
+      mag(i,j,k) = std::sqrt(mag_sq);
+    });
+  }
+
   void der_vel_avg (const Box& bx, FArrayBox& derfab, int dcomp, int ncomp,
             const FArrayBox& datfab, const Geometry& /*geomdata*/,
             Real /*time*/, const int* /*bcrec*/, int level)

--- a/Source/NS_setup.cpp
+++ b/Source/NS_setup.cpp
@@ -484,6 +484,11 @@ NavierStokes::variableSetUp ()
     derive_lst.addComponent("energy",desc_lst,State_Type,Density,1);
     derive_lst.addComponent("energy",desc_lst,State_Type,Xvel,AMREX_SPACEDIM);
     //
+    // velocity magnitude
+    //
+    derive_lst.add("velocity_magnitude",IndexType::TheCellType(),1,dermagvel,the_same_box);
+    derive_lst.addComponent("velocity_magnitude",desc_lst,State_Type,Xvel,AMREX_SPACEDIM);
+    //
     // magnitude of vorticity
     //
     derive_lst.add("mag_vort",IndexType::TheCellType(),1,dermgvort,grow_box_by_two);

--- a/Source/NavierStokes.cpp
+++ b/Source/NavierStokes.cpp
@@ -17,7 +17,9 @@
 #include <NS_kernels.H>
 
 #ifdef AMREX_PARTICLES
-#ifdef PARTICLE_PARALLEL
+#if (AMREX_SPACEDIM == 2)
+#include "DiffusedFiber.H"
+#elif defined(PARTICLE_PARALLEL)
 #include "DiffusedIB_Parallel.H"
 #else
 #include "DiffusedIB.H"
@@ -1214,8 +1216,27 @@ NavierStokes::writePlotFilePost (const std::string& dir,
 #endif
 
 #ifdef AMREX_PARTICLES
-    if(level == parent->finestLevel()){
-        Particles::get_particles()->mContainer->Checkpoint(dir, "particles");
+    if (do_diffused_ib && level == parent->finestLevel()) {
+#if (AMREX_SPACEDIM == 2)
+        auto* fibers = Fibers::get_fibers();
+        if (fibers && fibers->mContainer) {
+            fibers->mContainer->Checkpoint(dir, "fibers");
+        }
+#else
+        auto* particles = Particles::get_particles();
+        if (particles && particles->mContainer) {
+            particles->mContainer->Checkpoint(dir, "particles");
+#ifndef PARTICLE_PARALLEL
+            const int plot_step = parent->levelSteps(0);
+            const Real plot_time = state[State_Type].curTime();
+            for (const auto& body : particles->particle_kernels) {
+                if (body.geometry_type == 3) {
+                    mParticle::WriteFinVTK(plot_step, plot_time, body, "fin_vtk");
+                }
+            }
+#endif
+        }
+#endif
     }
 #endif
 
@@ -2667,7 +2688,9 @@ NavierStokes::advance_semistaggered_fsi_diffusedib (Real time,
 
         // Step 2: calculate pvf from the nodal level set function (only for internal cells)
         pvf.setVal(0.0);
+#if (AMREX_SPACEDIM == 3)
         nodal_phi_to_pvf(pvf, phi_nodal);
+#endif
 
         // Step 3 (optional): copy for visualization
         MultiFab&  S_new    = get_new_data(State_Type);
@@ -2725,16 +2748,24 @@ NavierStokes::advance_semistaggered_fsi_diffusedib (Real time,
         velocity_update(dt);
 
 #ifdef AMREX_PARTICLES
-        if (level == Particles::ParticleFinestLevel())//parent->finestLevel())
-        {
-            MultiFab&  S_new    = get_new_data(State_Type);
-            // S_new.setVal(1.0, 0, 1, S_new.nGrow()); // u = 1
-            // S_new.setVal(2.0, 1, 1, S_new.nGrow()); // v = 2
-            // S_new.setVal(3.0, 2, 1, S_new.nGrow()); // w = 3
-            MultiFab EulerForce(S_new.boxArray(), S_new.DistributionMap(), 3, S_new.nGrow());
-            Particles::get_particles()->InteractWithEuler(S_new, EulerForce, dt); // parent->levelSteps(0), time
+#if (AMREX_SPACEDIM == 2)
+        if (level == Fibers::FiberFinestLevel()) {
+            MultiFab& S_new = get_new_data(State_Type);
+            MultiFab EulerForce(S_new.boxArray(), S_new.DistributionMap(), 2, S_new.nGrow());
+            Fibers::get_fibers()->InteractWithEuler(S_new, EulerForce, dt, FOUR_POINT_IB, time + dt);
         }
-        //amrex::Abort("Stop here!");
+#else
+        if (level == Particles::ParticleFinestLevel()) {
+            MultiFab& S_new = get_new_data(State_Type);
+            MultiFab EulerForce(S_new.boxArray(), S_new.DistributionMap(), 3, S_new.nGrow());
+#ifdef PARTICLE_PARALLEL
+            Particles::get_particles()->InteractWithEuler(S_new, EulerForce, dt);
+#else
+            // Evaluate prescribed geometry and velocity at the new fluid time.
+            Particles::get_particles()->InteractWithEuler(S_new, EulerForce, dt, FOUR_POINT_IB, time + dt);
+#endif
+        }
+#endif
 #endif
         //
         // Increment rho average.
@@ -2779,12 +2810,22 @@ NavierStokes::advance_semistaggered_fsi_diffusedib (Real time,
             p_avg.setVal(0);
         }
 #ifdef AMREX_PARTICLES
-        if (level == Particles::ParticleFinestLevel())//parent->finestLevel())
-        {
-            MultiFab&  S_new    = get_new_data(State_Type);
-            MultiFab&  S_old    = get_old_data(State_Type);
-            Particles::get_particles()->UpdateParticles(parent->levelSteps(0), time, S_old, S_new, phi_nodal, pvf, dt);
+#if (AMREX_SPACEDIM == 2)
+        if (level == Fibers::FiberFinestLevel()) {
+            Fibers::get_fibers()->UpdateFibers(parent->levelSteps(level), time + dt, dt);
         }
+#else
+        if (level == Particles::ParticleFinestLevel()) {
+            MultiFab& S_new = get_new_data(State_Type);
+            MultiFab& S_old = get_old_data(State_Type);
+#ifdef PARTICLE_PARALLEL
+            Particles::get_particles()->UpdateParticles(parent->levelSteps(0), time, S_old, S_new, phi_nodal, pvf, dt);
+#else
+            Particles::get_particles()->UpdateParticles(parent->levelSteps(0), parent->levelSteps(level),
+                                                       time, S_old, S_new, phi_nodal, pvf, dt);
+#endif
+        }
+#endif
 #endif
 
 #ifdef AMREX_PARTICLES

--- a/Source/NavierStokesBase.cpp
+++ b/Source/NavierStokesBase.cpp
@@ -22,7 +22,9 @@
 #include <hydro_utils.H>
 
 #ifdef AMREX_PARTICLES
-#ifdef PARTICLE_PARALLEL
+#if (AMREX_SPACEDIM == 2)
+#include "DiffusedFiber.H"
+#elif defined(PARTICLE_PARALLEL)
 #include "DiffusedIB_Parallel.H"
 #else
 #include "DiffusedIB.H"
@@ -364,6 +366,17 @@ void NavierStokesBase::define_workspace()
         phi_nodal.define(nba,dmap,1,2,MFInfo(),Factory());
         pvf.define(grids,dmap,1,2,MFInfo(),Factory());
 #ifdef AMREX_PARTICLES
+#if (AMREX_SPACEDIM == 2)
+        phi_nodal.setVal(1.0);
+        pvf.setVal(0.0);
+        if (level == Fibers::FiberFinestLevel()) {
+            if (!Fibers::isInitial) {
+                Fibers::init_fiber(gravity, geom.CellSizeArray()[0]);
+            }
+            Fibers::get_fibers()->UpdateGeometry(state[State_Type].curTime());
+            Fibers::create_fibers(geom, dmap, grids);
+        }
+#else
         amrex::Print() << "check level " << level << " " << Particles::ParticleFinestLevel() << std::endl;
         if (level == Particles::ParticleFinestLevel()) {
             if(!Particles::isInitial){
@@ -373,6 +386,7 @@ void NavierStokesBase::define_workspace()
             //largra
             Particles::create_particles(geom, dmap, grids); // Class constructor
         }
+#endif
 #endif
     }
 
@@ -696,7 +710,13 @@ NavierStokesBase::Initialize ()
     amrex::ExecOnFinalize(NavierStokesBase::Finalize);
 
 #ifdef AMREX_PARTICLES
-    Particles::Initialize();
+    if (do_diffused_ib) {
+#if (AMREX_SPACEDIM == 2)
+        Fibers::Initialize();
+#else
+        Particles::Initialize();
+#endif
+    }
 #endif
 
     initialized = true;
@@ -2898,8 +2918,8 @@ NavierStokesBase::restart (Amr&          papa,
       computeGradP(state[Press_Type].prevTime());
     }
 
-#ifdef AMREX_PARTICLES
-    if(level == Particles::ParticleFinestLevel())
+#if defined(AMREX_PARTICLES) && (AMREX_SPACEDIM == 3)
+    if (do_diffused_ib && level == Particles::ParticleFinestLevel())
     {
         Particles::Restart(gravity, geom.CellSizeArray()[0],parent->levelSteps(0));
         ParallelDescriptor::Barrier();

--- a/Tutorials/Fiber/GNUmakefile
+++ b/Tutorials/Fiber/GNUmakefile
@@ -1,0 +1,32 @@
+#AMREX_HOME defines the directory in which we will find the AMReX directory
+AMREX_HOME       ?= ../../../amrex
+AMREX_HYDRO_HOME ?= ../../../AMReX-Hydro
+
+#TOP defines the directory in which we will find Source, Exec, etc.
+TOP = ../..
+
+#
+# Variables for the user to set ...
+#
+
+PRECISION   = DOUBLE
+
+DIM         = 2
+COMP        = gnu
+
+DEBUG       = TRUE
+USE_MPI     = TRUE
+USE_OMP     = FALSE
+PROFILE     = FALSE
+USE_PARTICLES = TRUE
+PARTICLE_PARALLEL = FALSE
+
+USE_CUDA = FALSE
+
+USE_SENSEI_INSITU = FALSE
+
+EBASE = amr
+
+Blocs   := .
+
+include $(TOP)/Exec/Make.IAMR

--- a/Tutorials/Fiber/README.md
+++ b/Tutorials/Fiber/README.md
@@ -1,0 +1,59 @@
+# Two-dimensional traveling-wave fin (fiber)
+
+This case imports the prescribed fiber implementation from
+[kkdxtd/IAMReX-2dIBMdev](https://github.com/kkdxtd/IAMReX-2dIBMdev), commit
+`78e0184b`, into the current IAMReX solver. The implementation is in
+`Source/DiffusedFiber.H` and `Source/DiffusedFiber.cpp`.
+
+## Configuration
+
+Use `GNUmakefile` with `DIM=2` and `USE_PARTICLES=TRUE`, and the input file
+`inputs.2d.flow_past_fiber`. The input prefix is `fiber.input = fiber_inputs`.
+AMReX and AMReX-Hydro paths can be supplied through `AMREX_HOME` and
+`AMREX_HYDRO_HOME`. Compilation and numerical validation of this integration
+are left to the user; neither was performed during the merge.
+
+The original motion is preserved, including its use of the absolute x coordinate:
+
+```text
+x_i = x0 + i*h
+y_i(t) = y0 + A*sin(2*pi*(t/T - n*x_i/L) + phase)
+u_i(t) = 0
+v_i(t) = (2*pi*A/T)*cos(2*pi*(t/T - n*x_i/L) + phase)
+```
+
+Here `h` is the finest-level Eulerian x spacing. As in the original code,
+the actual marker count is `ceil(L/h)+1` and each marker uses area `h*h`.
+`num_marker` remains a required legacy input but does not override that count.
+Consequently the last marker can extend by less than `h` beyond `x0+L`.
+The prescribed positions and target velocities are evaluated at `time+dt`
+before coupling to the new fluid state, and reconstructed from the checkpoint
+time on restart. The initial velocity also follows the analytic motion.
+
+The supplied case retains the original physical parameters: domain `10 x 5`,
+mesh `512 x 256`, origin `(4,2.5)`, amplitude `0.02`, period `0.5`, length `1`,
+wave number `1`, and unit inflow speed and density. Unused third components
+have been removed from the two-dimensional input vectors.
+
+`inputs.2d.flow_past_fiber.water` also preserves the alternative input formerly
+stored at the 2D repository root (`inputs.2d.flow_past_fiber.txt`): density
+`1000`, inflow speed `2`, fixed `dt=0.005`, and `max_step=300`. It uses the same
+fin geometry; only unused third components and explicit default IBM settings
+were adjusted when importing it.
+
+## Outputs and limitations
+
+- `IB_Fiber_1.csv`: `iStep,time,Fx,Fy`. `write_freq` counts finest-level steps.
+- The CSV preserves the old convention: integrated acceleration applied to
+  the fluid, `sum(a_marker*h*h)`. Multiply by `-ns.fluid_rho` for fluid-on-fin
+  force per unit out-of-plane span. This differs from the already dimensional,
+  fluid-on-fin loads in the 3D `IB_Fin_1.csv`.
+- The standard AMReX plotfile includes a `fibers` marker dataset. Verbose
+  marker dumps are named `fiberNNNNN`.
+- This tutorial uses one prescribed fiber. The legacy shared container requires
+  equal actual marker counts if multiple fibers are specified. No rigid-body
+  collision, closed body volume fraction, or 6-DOF update is applied to fibers.
+- The imported position-and-velocity penalty formula is retained. This merge
+  does not add a flexible structural solver or change marker quadrature.
+- Only source, configuration and documentation are versioned; generated loads,
+  marker dumps, plotfiles, checkpoints and executables are ignored.

--- a/Tutorials/Fiber/inputs.2d.flow_past_fiber
+++ b/Tutorials/Fiber/inputs.2d.flow_past_fiber
@@ -1,0 +1,228 @@
+
+#*******************************************************************************
+# INPUTS.2D.FLOW_PAST_Fiber
+#*******************************************************************************
+
+#NOTE: You may set *either* max_step or stop_time, or you may set them both.
+
+# Maximum number of coarse grid timesteps to be taken, if stop_time is
+#  not reached first.
+max_step 		= -1
+
+# Time at which calculation stops, if max_step is not reached first.
+stop_time 		= 3.1
+
+ns.fixed_dt     = -0.005
+ns.init_dt = 0.005
+ns.cfl = 0.3
+ns.init_iter = 0
+
+# Diffused IB input file
+#particle.input = particle_inputs
+fiber.input = fiber_inputs
+
+# Refinement criterion, use vorticity and presence of tracer
+amr.refinement_indicators = tracer
+
+amr.max_level		= 0 # maximum number of levels of refinement
+# amr.tracer.value_greater = 0.1
+# amr.tracer.value_less = 1.1
+amr.tracer.field_name = tracer
+amr.tracer.in_box_lo = 0.5 0.5
+amr.tracer.in_box_hi = 1.5 1.5
+
+amr.blocking_factor     = 8
+
+#*******************************************************************************
+
+# Number of cells in each coordinate direction at the coarsest level
+# amr.n_cell 		= 16 8 8
+amr.n_cell 		= 512 256
+# amr.n_cell 		= 288 128 128
+amr.max_grid_size	= 16
+# amr.max_grid_size	= 32
+
+#*******************************************************************************
+
+# Interval (in number of level l timesteps) between regridding
+amr.regrid_int		= 1 # regrid_int
+
+#*******************************************************************************
+
+# Refinement ratio as a function of level
+amr.ref_ratio		= 2 2 2 2
+
+#*******************************************************************************
+
+# Sets the "NavierStokes" code to be verbose
+ns.v                    = 1
+nodal_proj.verbose      = 1
+mac_proj.verbose        = 1
+
+# mac_proj.mac_tol        = 0.1
+# mac_proj.mac_abs_tol    = 0.1
+
+#*******************************************************************************
+
+# Sets the "amr" code to be verbose
+amr.v                   = 1
+
+#*******************************************************************************
+
+# Interval (in number of coarse timesteps) between checkpoint(restart) files
+
+amr.check_int		= 4000
+
+
+#*******************************************************************************
+
+# Interval (in number of coarse timesteps) between plot files
+amr.plot_int		= 1
+
+
+#*******************************************************************************
+
+# Viscosity coefficient
+ns.vel_visc_coef        = 0.01
+
+#*******************************************************************************
+
+# Diffusion coefficient for first scalar
+ns.scal_diff_coefs      = 0.0
+
+#*******************************************************************************
+
+# Forcing term defaults to  rho * abs(gravity) "down"
+ns.gravity              = 0.0 # -9.8
+
+#*******************************************************************************
+
+# skip level_projector
+ns.skip_level_projector = 0
+
+#*******************************************************************************
+
+# subcycling vs. non-subcycling
+amr.subcycling_mode     = None
+
+#*******************************************************************************
+
+# Set to 0 if x-y coordinate system, set to 1 if r-z.
+geometry.coord_sys   =  0
+
+#*******************************************************************************
+
+# Physical dimensions of the low end of the domain.
+geometry.prob_lo     =  0.0 0.0
+
+# Physical dimensions of the high end of the domain.
+geometry.prob_hi     =  10.0 5.0
+
+#*******************************************************************************
+
+#Set to 1 if periodic in that direction
+geometry.is_periodic =  0 0
+
+#*******************************************************************************
+
+# Boundary conditions on the low end of the domain.
+ns.lo_bc             = 1 5
+
+# Boundary conditions on the high end of the domain.
+ns.hi_bc             = 2 5
+
+# 0 = Interior/Periodic  3 = Symmetry
+# 1 = Inflow             4 = SlipWall
+# 2 = Outflow            5 = NoSlipWall
+
+# Boundary condition
+xlo.velocity            =   1.  0.
+
+#*******************************************************************************
+
+# Problem parameters
+prob.probtype = 1
+
+#*******************************************************************************
+
+# Add vorticity to the variables in the plot files.
+# amr.derive_plot_vars    = avg_pressure
+
+#*******************************************************************************
+ns.isolver            = 1
+ns.do_diffused_ib     = 1
+ns.fluid_rho          = 1
+
+#ns.sum_interval       = 1
+
+particles.do_nspc_particles = 0
+
+nodal_proj.proj_tol = 1.e-8
+nodal_proj.proj_abs_tol = 1.e-9
+
+nodal_proj.maxiter = 200
+nodal_proj.bottom_maxiter = 200
+
+mac_proj.mac_tol = 1.e-8
+mac_proj.mac_abs_tol = 1.e-9
+
+
+############################
+#                          #
+#  Diffused IB cfg file    #
+#                          #
+############################
+
+# particle's location
+# x = p1x p2x p3x ...
+#particle_inputs.x = 5.0
+#particle_inputs.y = 5.0
+#particle_inputs.z = 5.0
+
+# particle's density
+# rho = p1r p2r p3r ...
+#particle_inputs.rho = 1.0
+
+# particle's radius
+# single
+#particle_inputs.radius = 0.5
+
+# particle's velocity
+# vx = p1vx p2vx p3vx ...
+#particle_inputs.velocity_x = 0.0
+#particle_inputs.velocity_y = 0.0
+#particle_inputs.velocity_z = 0.0
+
+# particle's omega
+# omega = p1omega_x p2omega_x p3omega_x ...
+#particle_inputs.omega_x = 0.0
+#particle_inputs.omega_y = 0.0
+#particle_inputs.omega_z = 0.0
+
+# particle's 6DOF
+# TLX = p1tl p2tl ...
+#particle_inputs.TLX = 0
+#particle_inputs.TLY = 0
+#particle_inputs.TLZ = 0
+#particle_inputs.RLX = 0
+#particle_inputs.RLY = 0
+#particle_inputs.RLZ = 0
+
+
+# msg print
+#particle_inputs.verbose = 1
+
+
+#fiber
+fiber_inputs.x0 = 4
+fiber_inputs.y0 = 2.5
+fiber_inputs.amplitude = 0.02
+fiber_inputs.period = 0.5
+fiber_inputs.length = 1.0
+fiber_inputs.wave_number = 1
+fiber_inputs.phase = 0.0
+fiber_inputs.num_marker = 100
+fiber_inputs.verbose = 1
+
+fiber_inputs.LOOP_NS = 2
+fiber_inputs.write_freq = 1

--- a/Tutorials/Fiber/inputs.2d.flow_past_fiber.water
+++ b/Tutorials/Fiber/inputs.2d.flow_past_fiber.water
@@ -1,0 +1,227 @@
+
+#*******************************************************************************
+# INPUTS.2D.FLOW_PAST_Fiber
+#*******************************************************************************
+
+#NOTE: You may set *either* max_step or stop_time, or you may set them both.
+
+# Maximum number of coarse grid timesteps to be taken, if stop_time is
+#  not reached first.
+max_step 		= 300
+
+# Time at which calculation stops, if max_step is not reached first.
+stop_time 		= -1
+
+ns.fixed_dt     = 0.005
+ns.cfl = 0.5
+ns.init_iter = 0
+
+# Diffused IB input file
+#particle.input = particle_inputs
+fiber.input = fiber_inputs
+
+# Refinement criterion, use vorticity and presence of tracer
+amr.refinement_indicators = tracer
+
+amr.max_level		= 0 # maximum number of levels of refinement
+# amr.tracer.value_greater = 0.1
+# amr.tracer.value_less = 1.1
+amr.tracer.field_name = tracer
+amr.tracer.in_box_lo = 0.5 0.5
+amr.tracer.in_box_hi = 1.5 1.5
+
+amr.blocking_factor     = 8
+
+#*******************************************************************************
+
+# Number of cells in each coordinate direction at the coarsest level
+# amr.n_cell 		= 16 8 8
+amr.n_cell 		= 512 256
+# amr.n_cell 		= 288 128 128
+amr.max_grid_size	= 16
+# amr.max_grid_size	= 32
+
+#*******************************************************************************
+
+# Interval (in number of level l timesteps) between regridding
+amr.regrid_int		= 1 # regrid_int
+
+#*******************************************************************************
+
+# Refinement ratio as a function of level
+amr.ref_ratio		= 2 2 2 2
+
+#*******************************************************************************
+
+# Sets the "NavierStokes" code to be verbose
+ns.v                    = 1
+nodal_proj.verbose      = 1
+mac_proj.verbose        = 1
+
+# mac_proj.mac_tol        = 0.1
+# mac_proj.mac_abs_tol    = 0.1
+
+#*******************************************************************************
+
+# Sets the "amr" code to be verbose
+amr.v                   = 1
+
+#*******************************************************************************
+
+# Interval (in number of coarse timesteps) between checkpoint(restart) files
+
+amr.check_int		= 4000
+
+
+#*******************************************************************************
+
+# Interval (in number of coarse timesteps) between plot files
+amr.plot_int		= 1
+
+
+#*******************************************************************************
+
+# Viscosity coefficient
+ns.vel_visc_coef        = 0.01
+
+#*******************************************************************************
+
+# Diffusion coefficient for first scalar
+ns.scal_diff_coefs      = 0.0
+
+#*******************************************************************************
+
+# Forcing term defaults to  rho * abs(gravity) "down"
+ns.gravity              = 0.0 # -9.8
+
+#*******************************************************************************
+
+# skip level_projector
+ns.skip_level_projector = 0
+
+#*******************************************************************************
+
+# subcycling vs. non-subcycling
+amr.subcycling_mode     = None
+
+#*******************************************************************************
+
+# Set to 0 if x-y coordinate system, set to 1 if r-z.
+geometry.coord_sys   =  0
+
+#*******************************************************************************
+
+# Physical dimensions of the low end of the domain.
+geometry.prob_lo     =  0.0 0.0
+
+# Physical dimensions of the high end of the domain.
+geometry.prob_hi     =  10.0 5.0
+
+#*******************************************************************************
+
+#Set to 1 if periodic in that direction
+geometry.is_periodic =  0 0
+
+#*******************************************************************************
+
+# Boundary conditions on the low end of the domain.
+ns.lo_bc             = 1 5
+
+# Boundary conditions on the high end of the domain.
+ns.hi_bc             = 2 5
+
+# 0 = Interior/Periodic  3 = Symmetry
+# 1 = Inflow             4 = SlipWall
+# 2 = Outflow            5 = NoSlipWall
+
+# Boundary condition
+xlo.velocity            =   2.0  0.
+
+#*******************************************************************************
+
+# Problem parameters
+prob.probtype = 1
+
+#*******************************************************************************
+
+# Add vorticity to the variables in the plot files.
+# amr.derive_plot_vars    = avg_pressure
+
+#*******************************************************************************
+ns.isolver            = 1
+ns.do_diffused_ib     = 1
+ns.fluid_rho          = 1000
+
+#ns.sum_interval       = 1
+
+particles.do_nspc_particles = 0
+
+nodal_proj.proj_tol = 1.e-8
+nodal_proj.proj_abs_tol = 1.e-9
+
+nodal_proj.maxiter = 200
+nodal_proj.bottom_maxiter = 200
+
+mac_proj.mac_tol = 1.e-8
+mac_proj.mac_abs_tol = 1.e-9
+
+
+############################
+#                          #
+#  Diffused IB cfg file    #
+#                          #
+############################
+
+# particle's location
+# x = p1x p2x p3x ...
+#particle_inputs.x = 5.0
+#particle_inputs.y = 5.0
+#particle_inputs.z = 5.0
+
+# particle's density
+# rho = p1r p2r p3r ...
+#particle_inputs.rho = 1.0
+
+# particle's radius
+# single
+#particle_inputs.radius = 0.5
+
+# particle's velocity
+# vx = p1vx p2vx p3vx ...
+#particle_inputs.velocity_x = 0.0
+#particle_inputs.velocity_y = 0.0
+#particle_inputs.velocity_z = 0.0
+
+# particle's omega
+# omega = p1omega_x p2omega_x p3omega_x ...
+#particle_inputs.omega_x = 0.0
+#particle_inputs.omega_y = 0.0
+#particle_inputs.omega_z = 0.0
+
+# particle's 6DOF
+# TLX = p1tl p2tl ...
+#particle_inputs.TLX = 0
+#particle_inputs.TLY = 0
+#particle_inputs.TLZ = 0
+#particle_inputs.RLX = 0
+#particle_inputs.RLY = 0
+#particle_inputs.RLZ = 0
+
+
+# msg print
+#particle_inputs.verbose = 1
+
+
+#fiber
+fiber_inputs.x0 = 4
+fiber_inputs.y0 = 2.5
+fiber_inputs.amplitude = 0.02
+fiber_inputs.period = 0.5
+fiber_inputs.length = 1.0
+fiber_inputs.wave_number = 1
+fiber_inputs.phase = 0.0
+fiber_inputs.num_marker = 100
+fiber_inputs.verbose = 1
+
+fiber_inputs.LOOP_NS = 2
+fiber_inputs.write_freq = 1

--- a/Tutorials/fin3d/GNUmakefile
+++ b/Tutorials/fin3d/GNUmakefile
@@ -1,0 +1,24 @@
+# AMREX_HOME defines the directory in which we will find AMReX.
+AMREX_HOME       ?= ../../../amrex
+AMREX_HYDRO_HOME ?= ../../../AMReX-Hydro
+
+TOP = ../..
+
+PRECISION   = DOUBLE
+DIM         = 3
+COMP        = gnu
+
+DEBUG       = FALSE
+USE_MPI     = TRUE
+USE_OMP     = FALSE
+PROFILE     = FALSE
+USE_PARTICLES = TRUE
+PARTICLE_PARALLEL = FALSE
+USE_CUDA    = FALSE
+
+USE_SENSEI_INSITU = FALSE
+
+EBASE = amr
+Blocs := .
+
+include $(TOP)/Exec/Make.IAMR

--- a/Tutorials/fin3d/README.md
+++ b/Tutorials/fin3d/README.md
@@ -1,0 +1,65 @@
+# Three-dimensional traveling-wave fin
+
+This tutorial implements a prescribed three-dimensional traveling-wave fin coupled to IAMReX through the multidirect-forcing immersed-boundary method (DIBM). Two local AMR levels provide a broad 4 mm near-fin and wake mesh without storing that resolution over the whole domain.
+
+## Physical model
+
+The fin reference surface is parameterized by chord coordinate `s` and span coordinate `r`:
+
+```text
+X(s,r,t) = (x0+s, y0+r*cos(theta), z0+r*sin(theta))
+theta(s,t) = A*sin(2*pi*f*t - 2*pi*s/lambda + phase)
+```
+
+The analytic marker velocity is used directly as the no-slip target. The surface is prescribed: it does not enter the rigid-particle collision, PVF, or 6-DOF update paths.
+
+The merged input preserves the current local parameters: `L=0.8 m`, `span=0.052 m`, `A=85 deg`, `f=1.0 Hz`, `lambda=0.4 m`, `rho=1000 kg/m3`, and `nu=1e-6 m2/s`. The model was developed from the supplied Palabos fin example; the local frequency has since been changed.
+
+## Discretization
+
+- Domain: `4.0 x 1.6 x 1.6 m`.
+- Level 0 mesh: `250 x 100 x 100`, so `dx=16 mm`.
+- Two `2:1` refinement levels; Level 2 has `dx=4 mm` (three total grid levels: 16/8/4 mm).
+- Two nested physical boxes cover both the fin and its downstream wake. The broad Level-1 box is `(0.35,0.25,0.25)` to `(3.65,1.35,1.35) m`; the finest Level-2 box is `(0.65,0.45,0.45)` to `(3.35,1.15,1.15) m`.
+- Per-level blocking factors are `2 4 4`. Level 0 uses 2 because its x extent is 250 cells; refined levels use 4 to satisfy the IAMReX velocity/diffusion FillPatch proper-nesting requirement.
+- Lagrangian surface: `201 x 14` markers, approximately 4 mm apart in both parameter directions.
+- Four-point regularized Delta function and two multidirect-forcing iterations.
+- Smagorinsky LES with `Cs=0.12`.
+- Auto subcycling with Level-0 `dt=8.80256437073704e-3 s`; two `2:1` temporal refinements give `dt=2.20064109268426e-3 s` on Level 2.
+
+The marker volume used for force spreading is `dA*dx`; trapezoidal half weights are used on the four parameter-space edges. The reported load is the fluid-on-fin force:
+
+```text
+F_fin = -rho * sum(a_marker * dA * dx)
+```
+
+The moment is taken about the fin origin `(x0,y0,z0)`.
+
+## Files and outputs
+
+- `inputs.3d.fin`: complete two-level local-refinement (three total levels) run configuration.
+- `IB_Fin_1.csv`: step, physical time, phase, three force components, and three moment components. Force units are N and moment units are N m for SI inputs.
+- `fin_vtk/fin_XXXXXXXX.vtk`: legacy VTK PolyData time series in a dedicated directory. Files are triggered by the same output hook as the AMReX flow plotfiles, so if `amr.plot_int=12` is selected, `fin_00000012.vtk` corresponds to `plt00012`. Field data contains step, time, total fluid-on-fin force, and total moment. An initial plot, when enabled, also produces `fin_00000000.vtk`. The current input sets `amr.plot_int=-1`, disabling periodic flow and fin geometry output.
+- Standard AMReX plotfiles: flow-field state, including `x_velocity`, `y_velocity`, `z_velocity`, the derived scalar `velocity_magnitude=sqrt(u^2+v^2+w^2)`, and the directly evaluated vorticity magnitude `mag_vort`.
+
+The VTK writer reconstructs the prescribed geometry analytically on the I/O rank, so its topology remains ordered even after AMReX redistributes Lagrangian markers among MPI ranks. VTK output is tied to `amr.plot_int`; there is no separate fin VTK frequency. For a single fin the files are named `fin_XXXXXXXX.vtk`; multiple fins include the body ID in the prefix.
+
+In ParaView, `velocity_magnitude` is intended for speed contours and coloring. Vorticity must be calculated from a vector field, not from this scalar. Either use the plotfile's directly written `mag_vort`, or create a Calculator result such as `x_velocity*iHat + y_velocity*jHat + z_velocity*kHat`, name it `velocity`, and apply the Gradient/Vorticity filter to that vector.
+
+## Scope and current limitations
+
+- Refinement uses two static, nested physical boxes. They follow neither vorticity nor a freely translating body; their downstream extent is chosen to retain the principal wake and shed vortices at 4–8 mm resolution.
+- Level 0–2 use `1,2,4` relative temporal cycles. This avoids advancing every coarse level at the finest-level frequency.
+- The fin is a zero-thickness single Lagrangian surface.
+- Only one DIBM body is intended for this tutorial. Mixed fin/rigid-body cases and multiple fins with different marker counts are outside its supported scope.
+- Collision and 6-DOF dynamics are disabled for prescribed surfaces.
+- The DIBM load is an integrated total; pressure and viscous contributions are not separated.
+- The viscosity input is set to the dynamic viscosity of water (`1e-3 Pa s`) consistently with density-weighted IAMReX momentum diffusion. It should be kept in SI units with the other inputs.
+
+The current `write_freq=10` writes the force CSV every ten finest-level steps (approximately `0.0220 s`). Periodic flow/geometry snapshots are disabled by `amr.plot_int=-1`. Changing it to `12` enables both the AMReX plotfile and matching `fin_vtk/fin_XXXXXXXX.vtk` every twelve Level-0 steps (approximately `0.1056 s`). Positive `ns.fixed_dt` selects a fixed step; `ns.cfl` does not adapt this fixed step.
+
+## Integration and build selection
+
+Use `DIM=3`, `USE_PARTICLES=TRUE`, and `PARTICLE_PARALLEL=FALSE` for this fin. `USE_MPI=TRUE` remains supported by this DIBM path. Supply `AMREX_HOME` and `AMREX_HYDRO_HOME` for your dependency locations. The existing RKPM path remains separate and does not implement this prescribed fin.
+
+This merge includes source, inputs, documentation and `force-average.py`; no generated data or executable is included. The postprocessing script requires pandas, NumPy and matplotlib and reads your own `IB_Fin_1.csv`. No compilation, solver run or numerical test was performed for the merge.

--- a/Tutorials/fin3d/force-average.py
+++ b/Tutorials/fin3d/force-average.py
@@ -1,0 +1,110 @@
+import pandas as pd
+import numpy as np
+import matplotlib.pyplot as plt
+import os
+
+def calculate_and_plot():
+    file_name = 'IB_Fin_1.csv'
+
+    # 检查文件是否存在
+    if not os.path.exists(file_name):
+        print(f"错误: 找不到文件 '{file_name}'。请确保代码与CSV文件在同一目录下。")
+        return
+
+    # 读取CSV文件
+    print(f"正在读取 {file_name} ...\n")
+    df = pd.read_csv(file_name)
+
+    # 获取总的时间区间
+    total_t_min = df['time'].min()
+    total_t_max = df['time'].max()
+
+    print("="*40)
+    print(f"数据加载成功！")
+    print(f"总的时间区间为: {total_t_min:.6f} 秒 到 {total_t_max:.6f} 秒")
+    print("="*40)
+
+    # 设置绘图字体，防止中文乱码 (如果你系统不支持以下字体，图表将自动回退到默认英文字体)
+    plt.rcParams['font.sans-serif'] = ['SimHei', 'Microsoft YaHei', 'Arial']
+    plt.rcParams['axes.unicode_minus'] = False
+
+    while True:
+        try:
+            print("\n请输入你想计算的时间段 (输入 'q' 退出):")
+            start_input = input("起始时间 (start_time): ")
+            if start_input.lower() == 'q':
+                break
+
+            end_input = input("结束时间 (end_time): ")
+            if end_input.lower() == 'q':
+                break
+
+            t_start = float(start_input)
+            t_end = float(end_input)
+
+            if t_start >= t_end:
+                print("错误: 结束时间必须大于起始时间，请重新输入。")
+                continue
+
+            # 筛选该时间段内的数据
+            mask = (df['time'] >= t_start) & (df['time'] <= t_end)
+            filtered_df = df[mask]
+
+            if len(filtered_df) < 2:
+                print("错误: 该时间段内的数据点太少（少于2个），无法计算或绘图。请扩大时间范围。")
+                continue
+
+            # 提取时间和力的数据
+            t_array = filtered_df['time'].values
+            fx_array = filtered_df['Fx'].values
+
+            # 计算实际截取到的时间跨度
+            actual_time_span = t_array[-1] - t_array[0]
+
+            # 1. 积分时间平均值 (最准确的物理定义)
+            if hasattr(np, 'trapezoid'):
+                integral = np.trapezoid(fx_array, t_array)
+            else:
+                integral = np.trapz(fx_array, t_array)
+
+            time_avg_fx = integral / actual_time_span
+
+            # 2. 算数平均值 (仅供参考)
+            arithmetic_avg_fx = np.mean(fx_array)
+
+            print("-" * 40)
+            print(f"区间 [{t_array[0]:.6f}, {t_array[-1]:.6f}] 的计算结果:")
+            print(f"截取到的数据点数量: {len(filtered_df)}")
+            print(f"▶ 精确时间平均值 (积分法): {time_avg_fx:.6f}")
+            print(f"  (参考) 简单算数平均值: {arithmetic_avg_fx:.6f}")
+            print("-" * 40)
+
+            # 开始绘图
+            plt.figure(figsize=(10, 5)) # 设置图片大小
+
+            # 画出 Fx 随时间变化的真实曲线
+            plt.plot(t_array, fx_array, label='Fx 真实曲线', color='royalblue', linewidth=1.5)
+
+            # 画出表示时间平均值的红虚线
+            plt.axhline(y=time_avg_fx, color='red', linestyle='--', linewidth=2,
+                        label=f'时间平均值 = {time_avg_fx:.4f}')
+
+            # 填充曲线和平均值之间的区域（选作视觉增强，让波动更直观）
+            plt.fill_between(t_array, fx_array, time_avg_fx, color='royalblue', alpha=0.1)
+
+            # 设置图表标签和标题
+            plt.xlabel('Time (s)', fontsize=12)
+            plt.ylabel('Fx', fontsize=12)
+            plt.title(f'Fx 时间历程曲线 ({t_array[0]:.3f}s ~ {t_array[-1]:.3f}s)', fontsize=14)
+            plt.grid(True, linestyle=':', alpha=0.7)
+            plt.legend(loc='best', fontsize=11)
+
+            print(">> 提示: 请关闭弹出的图像窗口，即可继续下一次计算。")
+            # 显示图像 (程序会在此处暂停，直到你关闭图像窗口)
+            plt.show()
+
+        except ValueError:
+            print("错误: 输入无效，请输入数字。")
+
+if __name__ == "__main__":
+    calculate_and_plot()

--- a/Tutorials/fin3d/inputs.3d.fin
+++ b/Tutorials/fin3d/inputs.3d.fin
@@ -1,0 +1,186 @@
+# 三维静水中的预定行波仿生鳍运动（Three-dimensional prescribed traveling-wave fin in initially quiescent water）
+# 所有物理量均使用国际单位制 (SI units: m, kg, s, Pa)
+
+# ==========================================
+# 时间步与物理时间控制 (【已优化】)
+# ==========================================
+# 将 max_step 设置为 -1 表示取消大步数量限制。
+# 算例现在将完全根据自适应物理时间演化，直到跑满 stop_time 指定的 10.0 秒为止自动停止。
+max_step = -1
+stop_time = 10.0
+
+# Level-0 层的时间步长 dt。开启子循环后，每向下一层细网格，dt就会除以2。
+# 正的 ns.fixed_dt 指定固定时间步；若需要 CFL 自适应步长，请自行设置 ns.fixed_dt < 0。
+ns.fixed_dt = 8.80256437073704e-3
+ns.init_dt = 8.80256437073704e-3
+# CFL 参数仅在使用自适应时间步时控制步长。
+ns.cfl = 0.5
+ns.init_iter = 0
+
+# ==========================================
+# AMR (自适应网格细化) 与计算域设置
+# ==========================================
+# 指定粒子（浸入边界点）的输入配置前缀
+particle.input = fin_inputs
+
+# 总共3层网格（Level 0~2），包含2个局部细化层。
+# 加密比例在 x, y, z 方向均为2，分辨率依次为16/8/4 mm。
+amr.max_level = 2
+amr.ref_ratio = 2 2
+# Level 0 (全局计算域) 的网格数量，分辨率为 16 mm
+amr.n_cell = 250 100 100
+
+# 定义2个固定的细化区域名称。
+# 仿生鳍的运动范围大约在 x=[0.8, 1.6] 以及 y,z=[0.748, 0.852] 之间。
+# 两个区域都向下游(+x)延伸，以更完整地解析和显示脱落涡与尾迹。
+amr.refinement_indicators = fin_level1 fin_level2
+
+# 第1层加密：扩大后的外围流场与尾迹过渡区（分辨率8 mm）
+amr.fin_level1.in_box_lo = 0.35 0.25 0.25
+amr.fin_level1.in_box_hi = 3.65 1.35 1.35
+amr.fin_level1.max_level = 1
+
+# 第2层加密：扩大后的最密鳍面与主要尾迹区（分辨率4 mm）
+# 鳍前方保留0.15 m缓冲，下游延伸到x=3.35 m，横向覆盖中心线两侧0.35 m。
+amr.fin_level2.in_box_lo = 0.65 0.45 0.45
+amr.fin_level2.in_box_hi = 3.35 1.15 1.15
+amr.fin_level2.max_level = 2
+
+# AMR网格分块策略。
+amr.n_error_buf = 2
+amr.max_grid_size = 64
+# Blocking factor 保证网格切分时是指定数字的倍数。
+# Level 0 设置为2即可(因为250是2的倍数，但不是4的倍数)。
+# Levels 1-2 设置为4，确保速度/扩散插值模板严格嵌套，防止出现 NaN 错误。
+amr.blocking_factor = 2 4 4
+amr.regrid_int = -1
+amr.subcycling_mode = Auto
+
+# ==========================================
+# 数据输出控制 (I/O) (【已优化】)
+# ==========================================
+# 当前 -1 关闭周期流场 Plotfile 和对应的鳍 VTK 输出；若设为12，间隔约为0.1056秒。
+# 减少集群硬盘写入带来的 I/O 阻塞。
+amr.plot_int = -1
+# 记录 Checkpoint 用于断点续算的频率 (每 114 步记录一次)
+amr.check_int = 114
+
+# 额外衍生输出变量：除了基础的 u,v,w 速度，额外在结果文件中写入“速度幅值”和“涡量幅值(mag_vort)”。
+# 方便直接在 ParaView 中查看。
+amr.derive_plot_vars = velocity_magnitude mag_vort
+
+ns.v = 1
+amr.v = 1
+# 关闭泊松求解器的刷屏输出以保持 log 干净
+nodal_proj.verbose = 0
+mac_proj.verbose = 0
+
+# ==========================================
+# 流体物理属性与湍流模型
+# ==========================================
+# 水的物性：密度 1000 kg/m^3, 动力粘度(mu) 1.0e-3 Pa·s (对应运动粘度 nu=1e-6 m^2/s)
+ns.fluid_rho = 1000.0
+ns.vel_visc_coef = 1.0e-3
+ns.scal_diff_coefs = 0.0
+ns.gravity = 0.0
+
+# 开启大涡模拟 (LES)，采用经典 Smagorinsky 模型，常系数 Cs=0.12
+ns.do_LES = 1
+ns.LES_model = Smagorinsky
+ns.smago_Cs_cst = 0.12
+
+ns.skip_level_projector = 0
+ns.isolver = 1
+# 开启弥散型浸入边界法 (Diffuse Immersed Boundary Method, DIBM)
+ns.do_diffused_ib = 1
+
+# ==========================================
+# 几何计算域与边界条件
+# ==========================================
+geometry.coord_sys = 0
+geometry.prob_lo = 0.0 0.0 0.0
+geometry.prob_hi = 4.0 1.6 1.6
+geometry.is_periodic = 0 0 0
+
+# 边界条件类型：
+# x-low(左侧): 1表示速度入口 (给定0速度，相当于死水)
+# x-high(右侧): 2表示压力出口
+# y, z 方向(侧面): 4表示滑移壁面(Slip walls)
+ns.lo_bc = 1 4 4
+ns.hi_bc = 2 4 4
+xlo.velocity = 0.0 0.0 0.0
+
+# 初始场为静止水体
+prob.probtype = 1
+particles.do_nspc_particles = 0
+
+# ==========================================
+# 压力泊松求解器参数 (切勿随意改小！)
+# ==========================================
+# 这里的 maxiter 是线性求解器(多重网格)的最大迭代次数上限。
+# 虽然设定为200，但满足 proj_tol (1e-8) 精度后就会提前停止。
+# 绝对不能改为小数字(如4)，否则压力场不收敛直接导致程序崩溃。
+nodal_proj.proj_tol = 1.e-8
+nodal_proj.proj_abs_tol = 1.e-9
+nodal_proj.maxiter = 200
+nodal_proj.bottom_maxiter = 200
+mac_proj.mac_tol = 1.e-8
+mac_proj.mac_abs_tol = 1.e-9
+
+# ==========================================
+# DIBM 与 仿生鳍运动学配置 (fin_inputs)
+# ==========================================
+# 身体原点坐标，计算力矩时以此为参考点。
+fin_inputs.x = 0.8
+fin_inputs.y = 0.8
+fin_inputs.z = 0.8
+fin_inputs.rho = 1000.0
+
+# radius 为兼容旧版粒子解析器保留，此处做碰撞占位符，几何类型 3 下实际不起作用。
+fin_inputs.radius = 0.026
+fin_inputs.geometry_type = 3
+
+# 整体刚体平动/转动速度设定为 0 (静水原地拍动)
+fin_inputs.velocity_x = 0.0
+fin_inputs.velocity_y = 0.0
+fin_inputs.velocity_z = 0.0
+fin_inputs.omega_x = 0.0
+fin_inputs.omega_y = 0.0
+fin_inputs.omega_z = 0.0
+
+# 预定运动不需要平动和转动约束限制。
+fin_inputs.TLX = 0
+fin_inputs.TLY = 0
+fin_inputs.TLZ = 0
+fin_inputs.RLX = 0
+fin_inputs.RLY = 0
+fin_inputs.RLZ = 0
+
+# 行波方程参数设定：
+# X(s,r,t) = origin + (s, r*cos(theta), r*sin(theta))
+# theta(s,t) = A*sin(2*pi*f*t - 2*pi*s/lambda + phase)
+fin_inputs.fin_length = 0.8          # 鳍长 (m)
+fin_inputs.fin_span = 0.052          # 展长/厚度相关 (m)
+fin_inputs.fin_amplitude_deg = 85.0  # 拍动最大幅值 (角度)
+fin_inputs.fin_frequency = 1.0       # 拍动频率 f = 1.0 Hz
+fin_inputs.fin_wavelength = 0.4      # 行波波长 lambda = 0.4 m
+fin_inputs.fin_phase = 0.0           # 初始相位
+
+# 固壁网格标记点数量。
+# 201x14 对应弦向和展向约4 mm间距，与 Eulerian Level-2 网格匹配。
+# 避免继续使用1 mm点距造成过密插值和不必要的MPI通信开销。
+fin_inputs.fin_n_chord = 201
+fin_inputs.fin_n_span = 14
+
+# ==========================================
+# 流固耦合(DIBM)迭代控制 (【已优化】)
+# ==========================================
+# 【提速优化】：流体与固体力的耦合传递迭代次数降为 2 次。
+# 因为是给定位移的强迫运动，2次迭代足以保证力的稳定计算，从而大幅节省泊松求解时间。
+fin_inputs.LOOP_NS = 2
+fin_inputs.LOOP_SOLID = 1
+fin_inputs.RD = 0.0
+
+# 仿生受力数据输出频率 (每 10 个最细层时间步记录一次 CSV 表格)
+fin_inputs.write_freq = 10
+fin_inputs.verbose = 0


### PR DESCRIPTION
Add prescribed traveling-wave fins in both two and three dimensions to the IAMReX DIBM solver. The 2D fiber implementation from `kkdxtd/IAMReX-2dIBMdev` and the 3D fin development now coexist through dimension-specific source selection.

- **2D fiber:** retain the sinusoidal traveling-wave motion, marker spacing and penalty-force formulation in a dedicated `DiffusedFiber` module, configured through `fiber.input`.
- **3D fin:** add `geometry_type=3` with prescribed angular traveling-wave motion, analytic marker velocities, edge-weighted force spreading, integrated force/moment CSV output, and fin-surface VTK output synchronized with flow plotfiles.
- **Solver integration:** evaluate prescribed geometry and velocity at the new fluid time, reconstruct 2D geometry at initialization and restart, and use finest-level step counters for fin load output under AMR subcycling. Keep the existing rigid-body and RKPM interfaces separate from the fin-specific interfaces, while preserving upstream level-set and RKPM changes.
- **Examples and documentation:** add `Tutorials/Fiber` and `Tutorials/fin3d`, including input variants, model and force-convention documentation, and the existing 3D load-postprocessing script. Add a dimension-aware `velocity_magnitude` derived field and ignore rules for generated simulation files.

The changes include source, build configuration, example inputs, documentation, and a postprocessing script. No generated simulation results or binaries are added.
